### PR TITLE
probe(aclaude): TUI prototype — headless Claude Code with custom ratatui interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "similar",
  "tempfile",
  "thiserror 2.0.18",
  "tmux-cmc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,16 +9,42 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "crossterm",
+ "image",
  "insta",
+ "ratatui",
+ "ratatui-image",
  "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tmux-cmc",
+ "tokio",
  "toml",
 ]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -65,7 +91,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -76,7 +102,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -84,6 +110,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -104,10 +139,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -116,10 +203,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -188,7 +316,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -204,6 +332,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,10 +357,191 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.4",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -228,8 +551,23 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -250,8 +588,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -260,16 +623,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -279,6 +696,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -330,6 +753,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,7 +808,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -383,12 +816,23 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -501,7 +945,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -595,10 +1039,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "icy_sixel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85518b9086bf01117761b90e7691c0ef3236fa8adfb1fb44dd248fe5f87215d5"
+dependencies = [
+ "quantette",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -622,6 +1082,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,6 +1106,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -644,6 +1128,19 @@ dependencies = [
  "serde",
  "similar",
  "tempfile",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -669,6 +1166,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +1193,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +1226,21 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -717,10 +1261,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "lru-slab"
@@ -729,10 +1297,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -741,8 +1350,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -752,6 +1412,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -773,16 +1443,201 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "bytemuck",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -792,6 +1647,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -809,7 +1670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -819,6 +1680,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "quantette"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c98fecda8b16396ff9adac67644a523dd1778c42b58606a29df5c31ca925d174"
+dependencies = [
+ "bitvec",
+ "bytemuck",
+ "image",
+ "libm",
+ "num-traits",
+ "ordered-float 5.3.0",
+ "palette",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "rayon",
+ "ref-cast",
+ "wide",
 ]
 
 [[package]]
@@ -835,7 +1722,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -850,13 +1737,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -898,13 +1785,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -914,7 +1828,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -925,6 +1848,194 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.11.0",
+ "compact_str",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-image"
+version = "10.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c57add959ab80c9a92be620fa6f8e4a64f7c014829250ba78862e8d81a903cb5"
+dependencies = [
+ "base64-simd",
+ "icy_sixel",
+ "image",
+ "rand 0.8.5",
+ "ratatui",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "windows",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -987,12 +2098,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "itoa",
  "libc",
@@ -1006,11 +2126,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1061,6 +2181,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629516c85c29fe757770fa03f2074cf1eac43d44c02a3de9fc2ef7b0e207dfdd"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,7 +2228,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1144,16 +2279,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -1174,7 +2363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1184,16 +2373,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1223,8 +2450,14 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1236,7 +2469,79 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.11.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float 4.6.0",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -1245,7 +2550,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1256,8 +2572,29 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
 
 [[package]]
 name = "tinystr"
@@ -1291,7 +2628,7 @@ source = "git+https://github.com/ArcavenAE/tmux-cmc?branch=main#62db391444ee3d07
 dependencies = [
  "oneshot",
  "rustix 0.38.44",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1304,8 +2641,21 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1380,7 +2730,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -1430,10 +2780,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -1476,6 +2861,39 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "want"
@@ -1552,7 +2970,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1593,7 +3011,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1629,16 +3047,154 @@ dependencies = [
 ]
 
 [[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float 4.6.0",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wide"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ca908d26e4786149c48efcf6c0ea09ab0e06d1fe3c17dc1b4b0f1ca4a7e788"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1649,7 +3205,18 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1660,7 +3227,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1671,11 +3238,30 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1888,7 +3474,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1904,7 +3490,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1916,7 +3502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -1953,6 +3539,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1971,7 +3566,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1992,7 +3587,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2012,7 +3607,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2052,7 +3647,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2060,3 +3655,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ crossterm = "0.29"
 ratatui-image = { version = "10.0", default-features = false, features = ["crossterm"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 
+# Diff rendering
+similar = { version = "2", features = ["text"] }
+
 # Async (bridge subprocess I/O)
 tokio = { version = "1", features = ["sync", "rt", "macros", "io-util", "process", "time"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,15 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 # tmux control mode client
 tmux-cmc = { git = "https://github.com/ArcavenAE/tmux-cmc", branch = "main" }
 
+# TUI
+ratatui = "0.30"
+crossterm = "0.29"
+ratatui-image = { version = "10.0", default-features = false, features = ["crossterm"] }
+image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
+
+# Async (bridge subprocess I/O)
+tokio = { version = "1", features = ["sync", "rt", "macros", "io-util", "process", "time"] }
+
 [build-dependencies]
 chrono = "0.4"
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,21 +1,27 @@
 [advisories]
-ignore = []
+ignore = [
+    # time 0.3.45: DoS via stack exhaustion in RFC 2822 parsing.
+    # Fix (0.3.47) requires Rust 1.88, our MSRV is 1.85.
+    # We don't parse user-provided RFC 2822 dates — transitive dep
+    # from ratatui-widgets. Will resolve when MSRV bumps.
+    "RUSTSEC-2026-0009",
+]
 
 [licenses]
+# Conservative allow list — permissive licenses only, no copyleft.
+# Adding a new license requires explicit review.
 allow = [
-    "MIT",
+    "0BSD",
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
-    "ISC",
-    "Unicode-3.0",
-    "Unicode-DFS-2016",
-    "Zlib",
-    "CC0-1.0",
-    "OpenSSL",
-    "0BSD",
     "BSL-1.0",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+    "Zlib",
 ]
 
 [[licenses.exceptions]]
@@ -25,3 +31,8 @@ name = "webpki-roots"
 [bans]
 multiple-versions = "warn"
 wildcards = "allow"
+
+[sources]
+allow-git = [
+    "https://github.com/ArcavenAE/tmux-cmc",
+]

--- a/docs/research/tui-parity-plan-20260410.md
+++ b/docs/research/tui-parity-plan-20260410.md
@@ -1,0 +1,590 @@
+# Plan: aclaude TUI Feature Parity with Claude Code
+
+## Context
+
+The aclaude TUI prototype runs Claude Code as a headless subprocess via NDJSON
+streaming and renders a custom ratatui interface. It handles basic text streaming,
+tool name tracking, input history, tab completion, portrait overlay, and a status
+bar. This plan closes the feature gap with vanilla Claude Code while retaining
+aclaude's portrait feature and dual-mode bridge architecture.
+
+## Reference Architecture Analysis
+
+Patterns drawn from adversarial review of four Rust reimplementations
+(`aclaude/docs/research/rust-claude-reimplementations-20260410.md`) and
+deep source audit of `/tmp/rust-claude-review/`:
+
+**srg-claude-code-rust** (Apache-2.0, B+) — code-borrowable:
+- `AppStatus` 6-state enum gates input and drives rendering
+- Two-layer render cache: width-independent content + width-dependent borders
+- `CacheSplitPolicy` (soft 1.5KB / hard 4KB) splits at paragraph boundaries
+- LRU eviction via atomic `CACHE_ACCESS_TICK` counter
+- Panic-safe markdown: `catch_unwind()` + plain text fallback
+- `InlinePermission` with oneshot response channel back to bridge
+- `LayoutInvalidation` enum for targeted cache invalidation
+
+**pi_agent_rust** (MIT+rider, A-) — study patterns only:
+- `UiStreamDeltaBatcher`: 45ms/2KB hybrid threshold, coalesces consecutive
+  same-kind deltas into single flush. Tool events bypass batcher (immediate).
+- Two-level cache: per-message cache + conversation prefix cache. During
+  streaming, only tail (current response) re-renders; prefix is frozen.
+- `streaming_needs_markdown_renderer()` fast-path: byte scan for markup
+  characters, skip renderer for plain text.
+- `RenderBuffers` struct: reusable `String` allocations per frame region.
+- VCR cassettes: record NDJSON streams, auto-redact API keys, binary-safe.
+
+**claurst** (GPL-3.0, A-) — ideas only, no code:
+- `PermissionDialogKind` per tool type: Bash gets "allow prefix*" option,
+  FileWrite gets "project-level" scope, FileRead gets 3 options.
+- `DisplayMessage` enum: real messages + synthetic `SystemAnnotation`s
+  ("Context compacted here") injected without modifying history.
+- `RenderContext` struct: carries width, highlight flags, tool name mappings
+  to keep rendering functions pure.
+- Virtual list: only renders visible items for long conversations.
+- Notification banners with auto-fade for transient status messages.
+
+**Licensing discipline**: aclaude is MIT. Never copy GPL code (claurst).
+Study pi_agent_rust but don't copy (rider complexity). srg-claude-code-rust
+(Apache-2.0) and claw-code-rust (MIT) are safe to reference with attribution.
+
+---
+
+## Phase 1: Protocol Foundation — Full Event Vocabulary and Turn State
+
+**What it adds**: Tool calls show streaming input JSON with elapsed-time spinner.
+Completed tools show one-line preview. `system/init` populates session metadata.
+Token counts use actual context window from init. Text batching eliminates
+per-token re-renders.
+
+### State machine (validated by srg-claude-code-rust AppStatus)
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AppStatus {
+    Connecting,      // waiting for system/init
+    Ready,           // idle, accepting input
+    Thinking,        // assistant turn started, no content yet
+    Streaming,       // text_delta arriving
+    ToolRunning,     // tool_use in progress
+    Error,           // subprocess died, rate limit
+}
+```
+
+Input gated by status — only `Ready` accepts typed input. Status drives
+spinner, placeholder text, and status bar indicator.
+
+### Turn-based conversation model
+
+Replace flat `Vec<Message>` with structured turns. Includes synthetic
+annotation support (pattern from claurst DisplayMessage):
+
+```rust
+pub enum ConversationItem {
+    UserMessage { text: String },
+    AssistantTurn {
+        blocks: Vec<TurnBlock>,
+        is_active: bool,
+    },
+    SystemNotice { text: String },  // compact markers, auth notices
+}
+
+pub enum TurnBlock {
+    Text { content: String, is_streaming: bool },
+    ToolCall(ToolCallItem),
+    Thinking { content: String, is_streaming: bool, is_expanded: bool },
+}
+
+pub struct ToolCallItem {
+    pub id: String,
+    pub name: String,
+    pub input_json: String,
+    pub result_preview: String,
+    pub status: ToolStatus,
+    pub started_at: Instant,
+    pub is_expanded: bool,
+    pub cached_render: Option<Vec<Line<'static>>>,  // phase 2 cache
+}
+```
+
+### Render context (pattern from claurst RenderContext)
+
+```rust
+pub struct RenderCtx {
+    pub width: u16,
+    pub show_thinking: bool,
+    pub tools_collapsed: bool,
+}
+```
+
+Passed to all render functions. Keeps rendering pure — no reaching into
+global state.
+
+### Stateful NDJSON parser
+
+`parse_bridge_event` is currently stateless. The protocol requires tracking
+open tool calls across events (`content_block_stop` doesn't carry tool_use_id).
+Introduce `BridgeParser`:
+
+```rust
+pub struct BridgeParser {
+    pending_tool: Option<(String, String)>,  // (id, name)
+    pending_thinking: bool,
+}
+
+impl BridgeParser {
+    pub fn parse(&mut self, line: &str) -> Option<BridgeEvent> { ... }
+}
+```
+
+New `BridgeEvent` variants:
+- `SessionInit { session_id, permission_mode, available_slash_commands, context_window_size, model, version }`
+- `ToolCallStart { id, name }`
+- `ToolInputDelta { partial_json }`
+- `ToolCallStop`
+- `ThinkingStart`, `ThinkingDelta { text }`, `ThinkingStop`
+- `MessageStart`, `MessageStop`
+
+### Text batching (pattern from pi_agent_rust UiStreamDeltaBatcher)
+
+Buffer `TextDelta` events for 45ms or 2KB before flushing to conversation
+model. Coalesce consecutive text deltas into a single string. Tool events
+bypass the batcher — they flush immediately (tool state transitions must
+be visible without latency).
+
+```rust
+struct TextBatcher {
+    buffer: String,
+    last_flush: Instant,
+}
+
+impl TextBatcher {
+    fn push(&mut self, text: &str) -> Option<String> {
+        self.buffer.push_str(text);
+        if self.buffer.len() >= 2048
+            || self.last_flush.elapsed() >= Duration::from_millis(45)
+        {
+            self.last_flush = Instant::now();
+            Some(std::mem::take(&mut self.buffer))
+        } else {
+            None
+        }
+    }
+    fn flush(&mut self) -> Option<String> { ... }
+}
+```
+
+Integrated into the event loop's bridge event arm.
+
+### Files modified
+
+- `protocol_ext.rs` — BridgeParser struct, new BridgeEvent variants,
+  SessionMetrics gains `context_window_size`, `permission_mode`,
+  `available_slash_commands`
+- `bridge.rs` — reader task uses BridgeParser, add `--include-hook-events`
+  to subprocess args
+- `tui/app.rs` — AppStatus enum, ConversationItem model, RenderCtx,
+  rewrite apply_event and render_conversation
+- `tui/mod.rs` — TextBatcher in event loop, status-gated input
+
+### Events consumed
+
+`content_block_start`, `content_block_delta` (text_delta, input_json_delta,
+thinking_delta), `content_block_stop`, `message_start`, `message_delta`,
+`message_stop`, `system/init`.
+
+---
+
+## Phase 2: Tool Call Rendering and Diff Display
+
+**What it adds**: Edit tool calls render as unified diffs (green/red +/- lines).
+Read shows file content preview. Bash shows command and output. Write shows
+path. Completed tools cached for 20fps rendering efficiency.
+
+### Two-layer render cache (pattern from srg-claude-code-rust)
+
+Tool call rendering splits into width-independent content (cached on
+`ToolCallItem`) and width-dependent presentation (computed at render time).
+Cache is set when status transitions to `Complete` and invalidated only when
+`is_expanded` toggles.
+
+```rust
+// Layer 1: cached on ToolCallItem.cached_render (width-independent)
+fn render_tool_content(item: &ToolCallItem) -> Vec<Line<'static>>
+
+// Layer 2: applied at render time
+fn render_tool_with_frame(content: &[Line], width: u16, spinner_frame: u64) -> Vec<Line<'static>>
+```
+
+### New file: `src/tui/diff.rs`
+
+```rust
+pub fn render_tool_call(item: &ToolCallItem) -> Vec<Line<'static>>
+pub fn render_edit_diff(file: &str, old: &str, new: &str) -> Vec<Line<'static>>
+pub fn render_tool_result(name: &str, result: &str, expanded: bool) -> Vec<Line<'static>>
+```
+
+Uses `similar` crate (`TextDiff::from_lines`). 3 lines of context around
+changes. Truncate with `[... N more lines ...]`.
+
+### Tool-specific renderers (validated by all three projects)
+
+All three projects dispatch rendering by tool name:
+- `Edit` → header `~ file_path`, body = unified diff of old_string → new_string
+- `Read` → header `  file_path`, body = first 10 lines (expandable)
+- `Write` → header `+ file_path`, body = first 5 lines
+- `Bash` → header `$ command`, body = first 10 lines of output (expandable)
+- `Grep`/`Glob` → header with pattern, body = file list preview
+- Other → raw input_json truncated to 120 chars
+
+Max visible output lines: 12 (constant from srg-claude-code-rust). Expandable
+via Ctrl+O toggling `is_expanded`.
+
+### Files
+
+- `tui/diff.rs` (new)
+- `tui/app.rs` (render_conversation dispatches to diff.rs for tool blocks)
+- `tui/mod.rs` (pub mod diff)
+- `Cargo.toml` (`similar = { version = "2", features = ["text"] }`)
+
+---
+
+## Phase 3: Permission Mode and Approval Dialog
+
+**What it adds**: Shift+Tab cycles permission mode. Status bar shows current
+mode. Permission hook events render as inline approval dialogs. Press a/d to
+allow/deny.
+
+### Tool-specific permission options (pattern from claurst PermissionDialogKind)
+
+Different tools get different option sets:
+
+```rust
+pub enum PermissionPrompt {
+    Bash {
+        command: String,
+        options: Vec<PermissionOption>,  // allow once, session, prefix*, deny
+    },
+    FileEdit {
+        path: String,
+        options: Vec<PermissionOption>,  // allow once, session, project, deny
+    },
+    FileRead {
+        path: String,
+        options: Vec<PermissionOption>,  // allow once, session, deny
+    },
+    Generic {
+        tool: String,
+        description: String,
+        options: Vec<PermissionOption>,
+    },
+}
+```
+
+### Oneshot response channel (pattern from srg-claude-code-rust)
+
+Permission responses flow back to the bridge via oneshot channel, not
+through the main event loop. The bridge spawns a response handler that
+writes the approval/denial to subprocess stdin.
+
+### Permission mode cycling
+
+```rust
+pub enum PermissionMode {
+    Default, AcceptEdits, Plan, Auto, Bypass,
+}
+```
+
+Populated from `SessionInit.permission_mode`. Shift+Tab cycles. Status bar
+shows `[mode]` with color (green default, yellow acceptEdits/plan, red bypass).
+
+### Layout
+
+`TuiLayout` gains `permission_prompt: Rect` — 5 rows above input when active.
+Permission prompt blocks normal input (checked in handle_key before character
+input). Portrait unaffected.
+
+### Files
+
+- `tui/app.rs` (PermissionMode, PermissionPrompt, render_permission)
+- `tui/input.rs` (CyclePermissionMode, PermissionAllow/Deny, input gating)
+- `tui/layout.rs` (permission_prompt rect)
+- `tui/mod.rs` (handle permission actions)
+- `bridge.rs` (send_permission_response)
+- `protocol_ext.rs` (parse hook_event)
+
+---
+
+## Phase 4: Slash Commands and Dynamic Auto-Complete
+
+**What it adds**: All major slash commands. Dynamic command list from
+system/init. @ file path completion. Unknown commands forwarded to Claude Code.
+
+### Slash command dispatch
+
+Local commands handled by aclaude:
+- `/exit` — quit (already done)
+- `/login` — auth info (already done)
+- `/clear` — clear conversation display
+- `/help` — show available commands and keybindings
+- `/cost` — show session cost from metrics
+- `/persona` — portrait size (already done)
+
+Forwarded to Claude Code as user messages:
+- `/compact`, `/model`, `/init`, `/review`, `/bug`, `/stats`, `/doctor`
+- Any MCP/skill commands from `available_slash_commands`
+
+```rust
+pub enum SlashCmd {
+    Exit, Login, Clear, Help, Cost,
+    PortraitSize(String),
+    ForwardToAgent(String),  // send as user message
+    Unknown(String),
+}
+```
+
+### Dynamic tab completion
+
+`tab_complete` takes `available_slash_commands: &[String]` from AppState
+(populated by SessionInit). Merges with static local commands.
+
+### @ file path completion
+
+When input contains `@` followed by partial text, Tab completes file paths
+using `std::fs::read_dir` on the current directory. Insert completed path
+after `@`.
+
+### Transient notifications (pattern from claurst)
+
+Status messages auto-clear after 5 seconds instead of persisting until the
+next event. Track `status_message_at: Option<Instant>` in AppState, clear
+when elapsed > 5s.
+
+### Files
+
+- `tui/input.rs` (new SlashCmd variants, @ completion, dynamic commands)
+- `tui/app.rs` (available_slash_commands, notification timeout)
+- `tui/mod.rs` (handle Clear/Help/Cost/Forward)
+
+---
+
+## Phase 5: Keyboard Shortcuts and Cursor-Positioned Input
+
+**What it adds**: Full line editing (Ctrl+A/E/W/U), cursor positioning within
+the input buffer, mouse wheel scroll, Ctrl+G for external editor.
+
+### InputState (replaces bare String)
+
+All three projects track cursor position for mid-line editing:
+
+```rust
+pub struct InputState {
+    pub buffer: String,
+    pub cursor: usize,
+}
+
+impl InputState {
+    pub fn insert(&mut self, c: char) { ... }
+    pub fn delete_back(&mut self) { ... }
+    pub fn delete_word_back(&mut self) { ... }  // Ctrl+W
+    pub fn clear(&mut self) { ... }              // Ctrl+U
+    pub fn home(&mut self) { ... }               // Ctrl+A
+    pub fn end(&mut self) { ... }                // Ctrl+E
+}
+```
+
+### Mouse capture
+
+Enable `crossterm::event::EnableMouseCapture` during terminal setup.
+`Event::Mouse(ScrollUp/Down)` → scroll conversation.
+
+### External editor (Ctrl+G)
+
+Suspend TUI → write buffer to tempfile → launch `$EDITOR` → read result →
+resume TUI. Uses `tempfile` (already a dev-dep).
+
+### New keyboard shortcuts
+
+| Key | Action |
+|-----|--------|
+| Ctrl+A | Cursor to start of line |
+| Ctrl+E | Cursor to end of line |
+| Ctrl+W | Delete word backward |
+| Ctrl+U | Clear entire line |
+| Ctrl+G | Open external editor |
+| Alt+T | Toggle thinking display |
+| Mouse wheel | Scroll conversation |
+
+### Files
+
+- `tui/input.rs` (InputState struct, cursor ops, new shortcuts)
+- `tui/app.rs` (use InputState, show_thinking flag)
+- `tui/mod.rs` (mouse capture setup, editor suspend/resume)
+
+---
+
+## Phase 6: Thinking Block Display
+
+**What it adds**: Thinking content as collapsible panels. Collapsed by
+default, Alt+T toggles. Thinking effort in status bar.
+
+### Rendering
+
+Collapsed:
+```
+▸ Thinking (2.1k chars)
+```
+
+Expanded:
+```
+┌─ Thinking ──────────────────────┐
+│ Let me reason through this...    │
+│ First, I need to consider...     │
+└──────────────────────────────────┘
+```
+
+### Protocol
+
+Consumed from Phase 1's ThinkingStart/Delta/Stop events. `SessionMetrics`
+gains `thinking_chars: u64` for status bar display.
+
+### Files
+
+- `tui/app.rs` (thinking block rendering, show_thinking toggle)
+- `protocol_ext.rs` (thinking_chars metric)
+
+---
+
+## Phase 7: Markdown Rendering
+
+**What it adds**: Assistant text with styled markdown — bold, italic, inline
+code, fenced code blocks, headers, bullet lists.
+
+### Panic-safe rendering (pattern from srg-claude-code-rust)
+
+```rust
+pub fn render_markdown_safe(text: &str) -> Vec<Line<'static>> {
+    std::panic::catch_unwind(|| render_markdown(text))
+        .unwrap_or_else(|_| plain_text_fallback(text))
+}
+```
+
+### Fast-path check (pattern from pi_agent_rust)
+
+```rust
+fn needs_markdown_renderer(text: &str) -> bool {
+    // Quick byte scan for `, *, [, #, -, > — skip renderer for plain text
+}
+```
+
+Skip the markdown state machine for messages that are pure prose with no
+markup characters. Returns false for ~40% of assistant responses.
+
+### New file: `src/tui/markdown.rs`
+
+Minimal line-by-line state machine. No external crate. States: `Normal`,
+`InCodeBlock { lang }`. Detects: fenced code blocks, headers, bullets,
+inline bold/code.
+
+### Streaming text cache (pattern from pi_agent_rust prefix cache)
+
+Cache rendered output per committed text block. Only re-render the
+currently streaming block each frame. This is the conversation prefix
+cache: all finalized messages cached, only tail re-rendered.
+
+### Files
+
+- `tui/markdown.rs` (new)
+- `tui/mod.rs` (pub mod markdown)
+- `tui/app.rs` (use render_markdown_safe in render_conversation)
+
+---
+
+## Phase 8: Transcript Mode and Diagnostics Placeholder
+
+**What it adds**: Ctrl+O cycles normal → transcript → focus. LSP diagnostics
+placeholder after file edits.
+
+### Transcript mode
+
+Leave alternate screen, print full conversation as plain text to terminal's
+native scrollback buffer. Re-enter alternate screen on next Ctrl+O.
+
+### Focus mode
+
+`TuiLayout` gains `focus_mode: bool`. Hides status bar and input borders.
+Portrait retained.
+
+### Diagnostics placeholder
+
+`ToolCallItem` gains `diagnostics: Vec<DiagnosticEntry>` (empty for now).
+After Edit calls, render `[diagnostics: none]` as collapsed section.
+
+### Files
+
+- `tui/mod.rs` (transcript cycling)
+- `tui/layout.rs` (focus_mode)
+- `tui/app.rs` (TranscriptMode enum, diagnostics struct)
+
+---
+
+## Testing Strategy
+
+### VCR cassette testing (pattern from pi_agent_rust)
+
+Record real Claude Code NDJSON output to files in `tests/cassettes/`.
+Feed recorded lines through `BridgeParser` in tests. Enables deterministic
+testing of event parsing and state mutation without a live subprocess.
+
+Cassette scenarios:
+- Basic conversation (text streaming)
+- Tool call with Edit diff
+- Permission prompt (hook_event)
+- Thinking blocks
+- Rate limit event
+- system/init with full metadata
+
+Auto-redact: session IDs, any values matching API key patterns.
+
+### Snapshot testing
+
+Use existing `insta` for render output snapshots. Feed known AppState into
+render functions, capture ratatui Buffer, snapshot.
+
+---
+
+## Dependency Changes
+
+| Crate | Phase | License | Notes |
+|-------|-------|---------|-------|
+| `similar = "2"` | 2 | MIT | Already transitive via insta |
+| `tempfile = "3"` | 5 | MIT/Apache-2.0 | Already dev-dep |
+
+No new crate introductions.
+
+---
+
+## Portrait Invariant
+
+Every phase adds fields to `TuiLayout` — none remove or zero out `portrait`.
+New layout variants (permission_prompt, focus_mode) are additive. Portrait
+overlay renders last in the draw call, on top of conversation content.
+
+---
+
+## Verification
+
+After each phase:
+
+```sh
+cd aclaude && cargo build && cargo test && cargo clippy -- -D warnings && cargo +nightly fmt --all -- --check
+```
+
+Manual testing per phase:
+1. Type message → verify tool spinner with elapsed time, status transitions
+2. Ask Claude to edit a file → verify unified diff with +/- coloring
+3. Shift+Tab → verify permission mode cycles, status bar updates
+4. /help, /clear, /cost, Tab on /per → verify commands and completion
+5. Ctrl+A, Ctrl+E, Ctrl+W, mouse scroll → verify cursor and editing
+6. Alt+T → verify thinking blocks toggle
+7. Verify markdown styling in assistant responses (bold, code blocks)
+8. Ctrl+O → verify transcript mode cycling

--- a/docs/research/tui-prototype-plan-20260410.md
+++ b/docs/research/tui-prototype-plan-20260410.md
@@ -1,0 +1,239 @@
+# Plan: Prototype TUI — Headless Claude Code with Portrait Overlay
+
+## Context
+
+aclaude currently spawns Claude Code with inherited stdio (user gets vanilla
+Claude Code TUI) or in NDJSON streaming mode (programmatic, no TUI). This
+probe builds a prototype ratatui TUI that wraps Claude Code as a headless
+subprocess, rendering its own UI around the NDJSON event stream. The TUI
+includes a persona portrait overlay in the upper-right corner with dynamic
+size switching via `/persona portrait size [small|medium|large|original]`.
+
+This is a PROBE — working demo quality, not production. The goal is to
+verify that the architecture works: bidirectional NDJSON streaming, ratatui
+rendering, portrait overlay via ratatui-image, and approximate Claude Code
+UX.
+
+## New dependencies (all MIT, no conflicts)
+
+```toml
+ratatui = "0.30"
+crossterm = "0.29"
+ratatui-image = { version = "10.0", default-features = false, features = ["crossterm"] }
+image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
+tokio = { version = "1", features = ["sync", "rt", "macros", "io-util", "process"] }
+```
+
+## New files
+
+```
+src/tui/
+  mod.rs              — entry point: run_tui(), terminal setup/teardown, event loop
+  app.rs              — AppState struct, PortraitSize enum, apply_event(), render fns
+  session_bridge.rs   — TuiSession: async subprocess spawn, bidirectional NDJSON
+  protocol_ext.rs     — TuiEvent enum extending ClaudeEvent with TextDelta, ToolResult, RateLimit
+  portrait_widget.rs  — PortraitWidget wrapping ratatui-image StatefulProtocol
+  input.rs            — handle_key(), slash command parser, InputAction enum
+  scroll.rs           — ScrollState with auto-scroll
+  layout.rs           — compute_layout() → portrait Rect + conversation + input + status
+```
+
+## Modified files
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` | Add 5 deps |
+| `src/lib.rs` | Add `pub mod tui;` |
+| `src/main.rs` | Add `Commands::Tui` subcommand |
+
+## Step 1: Cargo.toml
+
+Add ratatui, crossterm, ratatui-image, image, tokio to `[dependencies]`.
+
+## Step 2: `src/tui/protocol_ext.rs` — Extended event parsing
+
+New `TuiEvent` enum wrapping the existing `ClaudeEvent` plus:
+- `TextDelta { text }` — from `stream_event` with `content_block_delta`
+- `ToolResult { tool_use_id, content }` — from `user` type tool_result events
+- `RateLimit { status, resets_at }` — from `rate_limit_event`
+- `Core(ClaudeEvent)` — delegates to existing parser
+
+`parse_tui_event(line) -> Option<TuiEvent>` tries core parser first, then
+handles stream_event/rate_limit_event/user-tool_result.
+
+## Step 3: `src/tui/session_bridge.rs` — Async subprocess
+
+```rust
+pub struct TuiSession {
+    child: tokio::process::Child,
+    stdin: tokio::process::ChildStdin,
+    event_rx: mpsc::Receiver<TuiEvent>,
+}
+```
+
+`spawn()`: builds command with `claude -p --input-format stream-json
+--output-format stream-json --verbose --include-partial-messages
+--model X --append-system-prompt Y`, pipes stdin/stdout. Spawns a tokio
+task that reads stdout lines via `AsyncBufReadExt`, parses each with
+`parse_tui_event`, sends to `mpsc::channel(256)`.
+
+`send_user_message(text)`: writes `{"type":"user","message":{"role":"user","content":"..."}}\n` to stdin.
+
+`shutdown()`: kills child process gracefully.
+
+## Step 4: `src/tui/scroll.rs` — Scroll state
+
+ScrollState with offset, auto_scroll flag. Auto-scroll follows new content.
+Arrow keys / PageUp disable auto-scroll. End key re-enables.
+
+## Step 5: `src/tui/app.rs` — State and rendering
+
+**AppState:**
+- `messages: Vec<Message>` — conversation history
+- `streaming_text: String` — current partial response
+- `tool_calls: Vec<ToolCallEntry>` — tool use tracking
+- `input_buffer: String` — user input
+- `portrait_size: PortraitSize` — Small/Medium/Large/Original
+- `portrait_paths: PortraitPaths` — from existing resolve_portrait()
+- `session_usage: SessionUsage` — token/cost tracking
+- `is_waiting: bool` — between send and first response
+- `status_text: String` — rate limit notices
+- `scroll: ScrollState`
+- `model_name: String` — from config
+
+**apply_event(TuiEvent):** mutates state per event type.
+
+**Render functions:**
+- `render_conversation(frame, state, area)` — scrollable Paragraph with
+  styled user/assistant messages, streaming cursor, tool call entries
+- `render_input(frame, state, area)` — input box with placeholder text
+- `render_status(frame, state, area)` — model | tokens | cost | status
+
+## Step 6: `src/tui/portrait_widget.rs` — Image overlay
+
+```rust
+pub struct PortraitWidget {
+    picker: Picker,
+    image_state: Option<Box<dyn StatefulProtocol>>,
+    current_path: Option<PathBuf>,
+}
+```
+
+`new()`: calls `Picker::from_query_stdio()` after raw mode enabled, before
+Terminal::new(). Returns None if terminal doesn't support images.
+
+`set_size(size, portrait_paths)`: resolves best path for size, loads image
+with `image::open()`, creates protocol state via `picker.new_resize_protocol()`.
+Only reloads if path changed.
+
+`render(frame, area)`: renders `StatefulImage::new(None).resize(Resize::Fit(None))`
+at the given Rect.
+
+## Step 7: `src/tui/layout.rs` — Layout computation
+
+```
+┌─────────────────────────────┬──────────┐
+│ CONVERSATION VIEWPORT       │ PORTRAIT │
+│ (scrollable)                │ (upper   │
+│                             │  right)  │
+├─────────────────────────────┴──────────┤
+│ > INPUT AREA                            │
+├─────────────────────────────────────────┤
+│ STATUS BAR                              │
+└─────────────────────────────────────────┘
+```
+
+Portrait column widths: Small=20, Medium=32, Large=48, Original=min(64, w/3).
+Portrait hidden when terminal < 60 cols wide. Input = 3 rows. Status = 1 row.
+
+## Step 8: `src/tui/input.rs` — Key handling and slash commands
+
+`handle_key(event, state) -> InputAction` where InputAction is:
+- `SendMessage(text)` — send to subprocess
+- `SlashCommand(cmd)` — process locally
+- `Quit` — Ctrl+C
+- `ScrollUp/ScrollDown/ScrollEnd`
+- `None`
+
+Slash commands parsed from input: `/persona portrait size [small|medium|large|original]`.
+Invalid commands show brief status message.
+
+## Step 9: `src/tui/mod.rs` — Event loop
+
+```rust
+pub async fn run_tui(config, claude_args) -> Result<()>
+```
+
+1. Resolve portrait via existing `portrait::resolve_portrait()`
+2. `enable_raw_mode()`, then `Picker::from_query_stdio()`, then `Terminal::new()`
+3. Init PortraitWidget, set default size Medium
+4. Spawn `TuiSession::spawn()`
+5. Spawn crossterm event reader on `spawn_blocking` thread → mpsc channel
+6. 20fps tick timer via `tokio::time::interval(50ms)`
+7. `tokio::select!` loop over: subprocess events, terminal events, tick
+8. On tick: `terminal.draw()` with layout + all render functions
+9. Cleanup: shutdown session, disable raw mode, leave alternate screen
+
+## Step 10: `src/main.rs` — Entry point
+
+Add `Tui` to `Commands` enum:
+```rust
+/// Launch interactive TUI (prototype)
+Tui,
+```
+
+Match arm builds a single-threaded tokio runtime and calls `tui::run_tui()`.
+
+## Step 11: `src/lib.rs`
+
+Add `pub mod tui;`.
+
+## Implementation order
+
+1. Cargo.toml (deps, verify compile)
+2. protocol_ext.rs (no TUI deps, just parsing)
+3. session_bridge.rs (tokio + protocol_ext)
+4. scroll.rs (pure data)
+5. app.rs (state types + render functions)
+6. portrait_widget.rs (ratatui-image integration)
+7. layout.rs (layout math)
+8. input.rs (key handling + slash commands)
+9. mod.rs (event loop assembly)
+10. lib.rs + main.rs (wiring)
+
+## Intentionally deferred
+
+- Multi-line input (single line only)
+- Markdown rendering (plain text)
+- Tool input/output display (name only, not JSON args)
+- Session resume across TUI restarts
+- Error recovery / subprocess reconnect
+- Tmux statusline integration from TUI mode
+- Config persistence for portrait size
+- Mouse interaction
+- Paste support
+- Thinking block display (collapsed)
+
+## Verification
+
+```sh
+# Build
+cd aclaude && cargo build
+
+# Run tests
+cargo test
+
+# Launch TUI prototype
+cargo run -- tui
+
+# In the TUI:
+# - Type a message, press Enter → see streaming response
+# - /persona portrait size large → portrait resizes
+# - /persona portrait size small → portrait resizes
+# - Ctrl+C → clean exit
+# - Arrow keys → scroll conversation
+
+# Verify portrait renders in WezTerm
+# Verify graceful degradation without portrait cache
+# Verify subprocess cleanup on exit (no orphan claude processes)
+```

--- a/docs/research/tui-prototype-plan-dual-mode-20260410.md
+++ b/docs/research/tui-prototype-plan-dual-mode-20260410.md
@@ -1,0 +1,381 @@
+# Plan: Prototype TUI — Headless Claude Code with Portrait Overlay
+
+## Context
+
+aclaude currently spawns Claude Code with inherited stdio (user gets vanilla
+Claude Code TUI) or in NDJSON streaming mode (programmatic, no TUI). This
+probe builds a prototype ratatui TUI that wraps Claude Code as a headless
+subprocess, rendering its own UI around the NDJSON event stream. The TUI
+includes a persona portrait overlay in the upper-right corner with dynamic
+size switching via `/persona portrait size [small|medium|large|original]`.
+
+This is a PROBE — working demo quality, not production. The goal is to
+verify that the architecture works: bidirectional NDJSON streaming, ratatui
+rendering, portrait overlay via ratatui-image, and approximate Claude Code
+UX.
+
+### Dual-mode architecture (structural, not scope)
+
+tmux is always the substrate. Both human-operated and marvel-managed agent
+sessions run in tmux panes. The architecture accounts for two distinct
+consumers of the same Claude Code subprocess:
+
+**Human operator TUI** (this probe builds this): Rich, persona-themed
+ratatui interface. Conversation viewport, portrait overlay, input area,
+styled status bar. The user interacts directly with Claude Code through
+aclaude's rendering layer. This is the primary experience for a human
+choosing to use aclaude instead of vanilla Claude Code.
+
+**Marvel diagnostic view** (this probe enables, does not build): When
+marvel manages agent sessions autonomously, a human may attach to a
+tmux pane to inspect what an agent is doing. This is not a conversation
+interface — it's an inspection port. The operator sees: event log
+(tool calls, responses, thinking), session metrics (tokens, cost,
+context window), agent state (thinking, tool use, waiting), and manual
+controls (pause, resume, inject, signal). Think `kubectl logs` or
+`htop` — diagnostic, not interactive. The agent doesn't need a TUI to
+operate; the diagnostic view is for the human supervising it.
+
+The bridge pattern makes both possible without either knowing about the
+other. This probe builds consumer #1 (TUI) while ensuring consumer #2
+(diagnostic) can attach to the same bridge later.
+
+### tmux integration continuity
+
+The existing `session.rs` already writes tmux statusline data via
+tmux-cmc during streaming sessions. The bridge must continue this
+pattern — `SessionMetrics` updates flow to tmux statusline regardless
+of which view (TUI, diagnostic, or headless) is consuming the event
+stream. The statusline is a tmux concern, not a TUI concern. aclaude
+sessions always have a tmux pane; the statusline is always available.
+
+## Design Principles (coloring choices, not adding scope)
+
+The probe makes structural choices that lean toward the dual-mode future
+described in F16, F18, and the marvel resource model, without implementing
+those modes:
+
+1. **Session bridge is shared infrastructure, not TUI-specific.** The
+   subprocess lifecycle, NDJSON parsing, and event channel live at the
+   top level (`src/bridge.rs`, `src/protocol_ext.rs`), not inside
+   `src/tui/`. Both human TUI and future marvel diagnostic view consume
+   the same bridge. The bridge API has no ratatui types.
+
+2. **tmux is always present.** Both human TUI and marvel-managed agents
+   run in tmux panes. The bridge integrates with tmux-cmc for statusline
+   updates (continuing the pattern already in `session.rs` and
+   `statusline.rs`). Statusline writes happen at bridge level — any
+   consumer gets tmux status for free.
+
+3. **Status is always emittable.** `SessionMetrics` (tokens, cost,
+   context %, tool counts, rate limit status) is defined at bridge
+   level and updated by the bridge from event data. Any consumer can
+   read it — TUI status bar, tmux statusline, marvel sidecar file, or
+   a future diagnostic panel. The TUI reads metrics; it doesn't own them.
+
+4. **Config is watchable.** PortraitSize and other session-scoped config
+   live in AppState but are sourced from the config system. The probe
+   reads config once at startup. The struct is designed so a future
+   watcher (inotify on a marvel-provided sidecar config file) can mutate
+   it at runtime without restructuring.
+
+5. **Permission events are surfaced, not swallowed.** When Claude Code
+   emits permission-related events in the NDJSON stream, they become
+   typed events in the protocol layer. The TUI renders them as prompts.
+   A marvel diagnostic view could intercept them and respond
+   programmatically (auto-approve, escalate to supervisor, deny by
+   policy).
+
+6. **The bridge emits, the view consumes.** The session bridge is a
+   producer (mpsc channel of events). The TUI is one consumer. A marvel
+   diagnostic view would be another consumer of the same channel.
+   The bridge doesn't know what's rendering its events.
+
+## New dependencies (all MIT, no conflicts)
+
+```toml
+ratatui = "0.30"
+crossterm = "0.29"
+ratatui-image = { version = "10.0", default-features = false, features = ["crossterm"] }
+image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
+tokio = { version = "1", features = ["sync", "rt", "macros", "io-util", "process"] }
+```
+
+## New files
+
+```
+src/
+  bridge.rs            — Session: async subprocess lifecycle, bidirectional NDJSON pipes (SHARED)
+  protocol_ext.rs      — BridgeEvent enum, parse_bridge_event(), SessionMetrics (SHARED)
+  tui/
+    mod.rs             — entry point: run_tui(), terminal setup/teardown, event loop
+    app.rs             — AppState struct, PortraitSize enum, apply_event(), render fns
+    portrait_widget.rs — PortraitWidget wrapping ratatui-image StatefulProtocol
+    input.rs           — handle_key(), slash command parser, InputAction enum
+    scroll.rs          — ScrollState with auto-scroll
+    layout.rs          — compute_layout() → portrait Rect + conversation + input + status
+```
+
+**Why this layout:** `bridge.rs` and `protocol_ext.rs` are at `src/` level
+because they are TUI-agnostic. A future `src/dashboard/` (marvel diagnostic
+view) or a headless `src/agent.rs` (marvel workload, no rendering) would
+consume the same bridge and events. The `tui/` module is one view layer.
+
+## Modified files
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` | Add 5 deps |
+| `src/lib.rs` | Add `pub mod bridge;`, `pub mod protocol_ext;`, `pub mod tui;` |
+| `src/main.rs` | Add `Commands::Tui` subcommand |
+
+## Step 1: Cargo.toml
+
+Add ratatui, crossterm, ratatui-image, image, tokio to `[dependencies]`.
+
+## Step 2: `src/protocol_ext.rs` — Extended event parsing (SHARED)
+
+New `BridgeEvent` enum wrapping the existing `ClaudeEvent` plus:
+- `TextDelta { text }` — from `stream_event` with `content_block_delta`
+- `ToolResult { tool_use_id, content }` — from `user` type tool_result events
+- `RateLimit { status, resets_at }` — from `rate_limit_event`
+- `PermissionRequest { tool, path, description }` — from permission prompt events
+- `Core(ClaudeEvent)` — delegates to existing parser
+
+`parse_bridge_event(line) -> Option<BridgeEvent>` tries core parser first,
+then handles stream_event/rate_limit_event/user-tool_result/permission.
+
+Also defines `SessionMetrics` — a plain struct aggregating the session's
+observable state. Any consumer (TUI, tmux statusline, sidecar file, marvel
+control plane) can read it:
+
+```rust
+pub struct SessionMetrics {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cost_usd: f64,
+    pub context_pct: f64,
+    pub num_turns: u64,
+    pub tool_use_count: u64,
+    pub active_tool: Option<String>,
+    pub rate_limit_status: Option<String>,
+    pub model: String,
+    pub session_id: Option<String>,
+}
+```
+
+`SessionMetrics` is updated by `bridge.rs` from event data. TUI reads it
+for the status bar. Future marvel sidecar writes it to a JSON file for the
+control plane to poll.
+
+## Step 3: `src/bridge.rs` — Async subprocess session (SHARED)
+
+```rust
+pub struct Session {
+    child: tokio::process::Child,
+    stdin: tokio::process::ChildStdin,
+    event_rx: mpsc::Receiver<BridgeEvent>,
+    metrics: Arc<Mutex<SessionMetrics>>,
+}
+```
+
+`spawn()`: builds command with `claude -p --input-format stream-json
+--output-format stream-json --verbose --include-partial-messages
+--model X --append-system-prompt Y`, pipes stdin/stdout. Spawns a tokio
+task that reads stdout lines via `AsyncBufReadExt`, parses each with
+`parse_bridge_event`, updates `SessionMetrics`, sends to `mpsc::channel(256)`.
+
+When `SessionMetrics` updates and a tmux-cmc client is available, the
+bridge writes statusline data (continuing the pattern from `session.rs`
+line 152-166 and `statusline.rs`). This happens at bridge level so both
+TUI and headless/diagnostic modes get tmux statusline for free.
+
+`send_user_message(text)`: writes `{"type":"user","message":{"role":"user","content":"..."}}\n` to stdin.
+
+`metrics()`: returns `Arc<Mutex<SessionMetrics>>` — any consumer can read
+the latest metrics without going through the event channel. The TUI reads
+this for the status bar. A future marvel sidecar could clone the Arc and
+periodically serialize it to a JSON file.
+
+`shutdown()`: kills child process gracefully.
+
+**No ratatui types in this module.** The bridge is a subprocess manager
+and event producer. It doesn't know what renders its events. This is the
+component that both human TUI and marvel diagnostic mode share.
+
+## Step 4: `src/tui/scroll.rs` — Scroll state
+
+ScrollState with offset, auto_scroll flag. Auto-scroll follows new content.
+Arrow keys / PageUp disable auto-scroll. End key re-enables.
+
+## Step 5: `src/tui/app.rs` — State and rendering
+
+**AppState:**
+- `messages: Vec<Message>` — conversation history
+- `streaming_text: String` — current partial response
+- `tool_calls: Vec<ToolCallEntry>` — tool use tracking
+- `input_buffer: String` — user input
+- `portrait_size: PortraitSize` — Small/Medium/Large/Original
+- `portrait_paths: PortraitPaths` — from existing resolve_portrait()
+- `metrics: Arc<Mutex<SessionMetrics>>` — shared ref from bridge
+- `is_waiting: bool` — between send and first response
+- `scroll: ScrollState`
+- `pending_permission: Option<PermissionRequest>` — if Claude Code asks
+
+**apply_event(BridgeEvent):** mutates state per event type. Metrics are
+updated by the bridge (shared Arc), so the TUI just reads them on each
+frame rather than maintaining a separate copy.
+
+**PermissionRequest handling:** when a permission event arrives, the TUI
+sets `pending_permission` and renders a prompt. User approves/denies via
+the input handler. In the future, marvel could intercept this event at
+the bridge level and respond programmatically instead of routing it to
+the TUI.
+
+**Render functions:**
+- `render_conversation(frame, state, area)` — scrollable Paragraph with
+  styled user/assistant messages, streaming cursor, tool call entries
+- `render_input(frame, state, area)` — input box with placeholder text
+- `render_status(frame, state, area)` — model | tokens | cost | status
+
+## Step 6: `src/tui/portrait_widget.rs` — Image overlay
+
+```rust
+pub struct PortraitWidget {
+    picker: Picker,
+    image_state: Option<Box<dyn StatefulProtocol>>,
+    current_path: Option<PathBuf>,
+}
+```
+
+`new()`: calls `Picker::from_query_stdio()` after raw mode enabled, before
+Terminal::new(). Returns None if terminal doesn't support images.
+
+`set_size(size, portrait_paths)`: resolves best path for size, loads image
+with `image::open()`, creates protocol state via `picker.new_resize_protocol()`.
+Only reloads if path changed.
+
+`render(frame, area)`: renders `StatefulImage::new(None).resize(Resize::Fit(None))`
+at the given Rect.
+
+## Step 7: `src/tui/layout.rs` — Layout computation
+
+```
+┌─────────────────────────────┬──────────┐
+│ CONVERSATION VIEWPORT       │ PORTRAIT │
+│ (scrollable)                │ (upper   │
+│                             │  right)  │
+├─────────────────────────────┴──────────┤
+│ > INPUT AREA                            │
+├─────────────────────────────────────────┤
+│ STATUS BAR                              │
+└─────────────────────────────────────────┘
+```
+
+Portrait column widths: Small=20, Medium=32, Large=48, Original=min(64, w/3).
+Portrait hidden when terminal < 60 cols wide. Input = 3 rows. Status = 1 row.
+
+## Step 8: `src/tui/input.rs` — Key handling and slash commands
+
+`handle_key(event, state) -> InputAction` where InputAction is:
+- `SendMessage(text)` — send to subprocess
+- `SlashCommand(cmd)` — process locally
+- `Quit` — Ctrl+C
+- `ScrollUp/ScrollDown/ScrollEnd`
+- `None`
+
+Slash commands parsed from input: `/persona portrait size [small|medium|large|original]`.
+Invalid commands show brief status message.
+
+## Step 9: `src/tui/mod.rs` — Event loop
+
+```rust
+pub async fn run_tui(config, claude_args) -> Result<()>
+```
+
+1. Resolve portrait via existing `portrait::resolve_portrait()`
+2. `enable_raw_mode()`, then `Picker::from_query_stdio()`, then `Terminal::new()`
+3. Init PortraitWidget, set default size Medium
+4. Spawn `bridge::Session::spawn()` — shared bridge, not TUI-specific
+5. Clone `session.metrics()` Arc for the status bar
+6. Spawn crossterm event reader on `spawn_blocking` thread → mpsc channel
+7. 20fps tick timer via `tokio::time::interval(50ms)`
+8. `tokio::select!` loop over: subprocess events, terminal events, tick
+9. On tick: `terminal.draw()` with layout + all render functions
+10. Cleanup: shutdown session, disable raw mode, leave alternate screen
+
+The event loop is the only TUI-specific orchestration. The bridge runs
+independently. For a marvel diagnostic view, steps 2-3 and 6 would be
+different — no portrait, no user input area, but instead: scrollable
+event log (tool calls with args/results, text responses, thinking
+indicators), metrics panel (tokens, cost, context %, agent state), and
+manual controls (pause, inject prompt, send signal). Steps 4-5 and
+8-10 would be identical — same bridge, same metrics Arc, same event
+channel, same cleanup.
+
+## Step 10: `src/main.rs` — Entry point
+
+Add `Tui` to `Commands` enum:
+```rust
+/// Launch interactive TUI (prototype)
+Tui,
+```
+
+Match arm builds a single-threaded tokio runtime and calls `tui::run_tui()`.
+
+## Step 11: `src/lib.rs`
+
+Add `pub mod tui;`.
+
+## Implementation order
+
+1. Cargo.toml (deps, verify compile)
+2. protocol_ext.rs (no TUI deps, just parsing)
+3. session_bridge.rs (tokio + protocol_ext)
+4. scroll.rs (pure data)
+5. app.rs (state types + render functions)
+6. portrait_widget.rs (ratatui-image integration)
+7. layout.rs (layout math)
+8. input.rs (key handling + slash commands)
+9. mod.rs (event loop assembly)
+10. lib.rs + main.rs (wiring)
+
+## Intentionally deferred
+
+- Marvel diagnostic view (the second bridge consumer — enabled by architecture, not built here)
+- Multi-line input (single line only)
+- Markdown rendering (plain text)
+- Tool input/output display (name only, not JSON args)
+- Session resume across TUI restarts
+- Error recovery / subprocess reconnect
+- Config persistence for portrait size
+- Mouse interaction
+- Paste support
+- Thinking block display (collapsed)
+- Marvel sidecar metrics export (SessionMetrics → JSON file for control plane polling)
+
+## Verification
+
+```sh
+# Build
+cd aclaude && cargo build
+
+# Run tests
+cargo test
+
+# Launch TUI prototype
+cargo run -- tui
+
+# In the TUI:
+# - Type a message, press Enter → see streaming response
+# - /persona portrait size large → portrait resizes
+# - /persona portrait size small → portrait resizes
+# - Ctrl+C → clean exit
+# - Arrow keys → scroll conversation
+
+# Verify portrait renders in WezTerm
+# Verify graceful degradation without portrait cache
+# Verify subprocess cleanup on exit (no orphan claude processes)
+```

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -1,0 +1,258 @@
+//! Session bridge — async subprocess lifecycle for Claude Code.
+//!
+//! Spawns `claude` as a headless subprocess with bidirectional NDJSON streaming.
+//! Parses events, updates `SessionMetrics`, and sends events to consumers via
+//! an mpsc channel. The bridge is TUI-agnostic — no ratatui types.
+//!
+//! Both human TUI and future marvel diagnostic view consume the same bridge.
+//! tmux statusline updates happen here so any consumer gets status for free.
+
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::mpsc;
+
+use crate::config::AclaudeConfig;
+use crate::error::{AclaudeError, Result};
+use crate::persona;
+use crate::protocol::ClaudeEvent;
+use crate::protocol_ext::{self, BridgeEvent, SessionMetrics};
+use crate::session::find_claude;
+use crate::statusline;
+
+/// A running Claude Code subprocess with event streaming.
+///
+/// The bridge owns the child process and provides:
+/// - An event receiver (mpsc) for consuming NDJSON events
+/// - Shared metrics via `Arc<Mutex<SessionMetrics>>`
+/// - Methods to send user messages and shut down
+pub struct Session {
+    child: Child,
+    event_rx: mpsc::Receiver<BridgeEvent>,
+    metrics: Arc<Mutex<SessionMetrics>>,
+    stdin_tx: mpsc::Sender<String>,
+}
+
+impl Session {
+    /// Spawn a Claude Code subprocess with NDJSON streaming.
+    ///
+    /// Starts `claude` with `--output-format stream-json --input-format stream-json
+    /// --verbose --include-partial-messages` and the persona system prompt.
+    ///
+    /// Returns a `Session` that produces `BridgeEvent`s via its event receiver
+    /// and accepts user messages via `send_user_message`.
+    pub async fn spawn(config: &AclaudeConfig) -> Result<Self> {
+        let claude_path = find_claude()?;
+
+        let system_prompt = {
+            let theme = persona::load_theme(&config.persona.theme)?;
+            let agent = persona::get_agent(&theme, &config.persona.role)?;
+            persona::build_system_prompt(&theme, agent, &config.persona.immersion)
+        };
+
+        let mut cmd = Command::new(&claude_path);
+        cmd.args(["--output-format", "stream-json"])
+            .args(["--input-format", "stream-json"])
+            .args(["--verbose"])
+            .args(["--include-partial-messages"])
+            .args(["--model", &config.session.model])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::inherit());
+
+        if !system_prompt.is_empty() {
+            cmd.args(["--append-system-prompt", &system_prompt]);
+        }
+
+        let mut child = cmd.spawn().map_err(|e| AclaudeError::Session {
+            message: format!("failed to start claude: {e}"),
+        })?;
+
+        let stdout = child.stdout.take().ok_or_else(|| AclaudeError::Session {
+            message: "failed to capture claude stdout".to_string(),
+        })?;
+
+        let child_stdin = child.stdin.take().ok_or_else(|| AclaudeError::Session {
+            message: "failed to capture claude stdin".to_string(),
+        })?;
+
+        let metrics = Arc::new(Mutex::new(SessionMetrics {
+            model: config.session.model.clone(),
+            ..SessionMetrics::default()
+        }));
+
+        let (event_tx, event_rx) = mpsc::channel::<BridgeEvent>(256);
+        let (stdin_tx, mut stdin_rx) = mpsc::channel::<String>(32);
+
+        // Reader task: stdout → parse → metrics update → event channel
+        let reader_metrics = Arc::clone(&metrics);
+        let statusline_config = config.clone();
+        tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if line.is_empty() {
+                    continue;
+                }
+                if let Some(event) = protocol_ext::parse_bridge_event(&line) {
+                    // Update shared metrics from event data
+                    update_metrics(&reader_metrics, &event);
+
+                    // Push tmux statusline (bridge-level, any consumer gets this)
+                    push_statusline_from_metrics(&reader_metrics, &statusline_config);
+
+                    // Send to consumer — if channel is full or closed, drop the event
+                    if event_tx.send(event).await.is_err() {
+                        break;
+                    }
+                }
+            }
+        });
+
+        // Writer task: stdin channel → child stdin
+        tokio::spawn(async move {
+            let mut stdin = child_stdin;
+            while let Some(msg) = stdin_rx.recv().await {
+                if stdin.write_all(msg.as_bytes()).await.is_err() {
+                    break;
+                }
+                if stdin.flush().await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(Session {
+            child,
+            event_rx,
+            metrics,
+            stdin_tx,
+        })
+    }
+
+    /// Get the event receiver for consuming bridge events.
+    ///
+    /// The receiver yields `BridgeEvent`s as they arrive from the subprocess.
+    /// When the subprocess exits, the channel closes.
+    pub fn event_rx(&mut self) -> &mut mpsc::Receiver<BridgeEvent> {
+        &mut self.event_rx
+    }
+
+    /// Get a shared reference to session metrics.
+    ///
+    /// Any consumer can clone this Arc and read metrics independently of
+    /// the event channel. The TUI reads it for the status bar. A future
+    /// marvel sidecar could serialize it to a JSON file.
+    pub fn metrics(&self) -> Arc<Mutex<SessionMetrics>> {
+        Arc::clone(&self.metrics)
+    }
+
+    /// Send a user message to the Claude Code subprocess.
+    ///
+    /// Writes the NDJSON user message format to stdin.
+    pub async fn send_user_message(&self, text: &str) -> Result<()> {
+        let msg = serde_json::json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": text
+            }
+        });
+        let line = format!(
+            "{}\n",
+            serde_json::to_string(&msg).map_err(|e| {
+                AclaudeError::Session {
+                    message: format!("failed to serialize message: {e}"),
+                }
+            })?
+        );
+        self.stdin_tx
+            .send(line)
+            .await
+            .map_err(|_| AclaudeError::Session {
+                message: "subprocess stdin closed".to_string(),
+            })
+    }
+
+    /// Gracefully shut down the subprocess.
+    pub async fn shutdown(&mut self) {
+        // Drop the stdin sender to signal EOF
+        // (already dropped when Session is dropped, but explicit is clearer)
+        let _ = self.child.kill().await;
+        let _ = self.child.wait().await;
+    }
+}
+
+/// Update `SessionMetrics` from a `BridgeEvent`.
+fn update_metrics(metrics: &Arc<Mutex<SessionMetrics>>, event: &BridgeEvent) {
+    let mut m = match metrics.lock() {
+        Ok(guard) => guard,
+        Err(_) => return,
+    };
+    match event {
+        BridgeEvent::Core(ClaudeEvent::System { session_id }) => {
+            m.session_id = Some(session_id.clone());
+        }
+        BridgeEvent::Core(ClaudeEvent::Assistant { message }) => {
+            // Track tool uses
+            for block in &message.content {
+                if block.block_type == "tool_use" {
+                    m.tool_use_count += 1;
+                    m.active_tool = block.name.clone();
+                }
+            }
+            // Update token counts
+            if let Some(usage) = &message.usage {
+                m.input_tokens += usage.input_tokens;
+                m.output_tokens += usage.output_tokens;
+                m.cache_read_tokens += usage.cache_read_input_tokens;
+                m.cache_creation_tokens += usage.cache_creation_input_tokens;
+                m.update_context_pct(200_000);
+            }
+        }
+        BridgeEvent::Core(ClaudeEvent::Result { payload }) => {
+            m.cost_usd = payload.cost_usd;
+            m.num_turns = payload.num_turns;
+            m.active_tool = None;
+        }
+        BridgeEvent::RateLimit { status, .. } => {
+            m.rate_limit_status = Some(status.clone());
+        }
+        BridgeEvent::ToolResult { .. } => {
+            // Tool completed — clear active tool
+            m.active_tool = None;
+        }
+        _ => {}
+    }
+}
+
+/// Push tmux statusline from current metrics.
+///
+/// Continues the pattern from `session.rs` — statusline updates happen at
+/// bridge level so any consumer (TUI, headless, diagnostic) gets tmux
+/// status for free.
+fn push_statusline_from_metrics(metrics: &Arc<Mutex<SessionMetrics>>, config: &AclaudeConfig) {
+    if !config.statusline.enabled {
+        return;
+    }
+    let m = match metrics.lock() {
+        Ok(guard) => guard,
+        Err(_) => return,
+    };
+
+    // Only update when we have token data
+    if m.input_tokens == 0 {
+        return;
+    }
+
+    let character_name = config
+        .persona
+        .theme
+        .split('/')
+        .next_back()
+        .unwrap_or("aclaude");
+    let left = statusline::render_statusline(config, character_name, Some(m.context_pct));
+    let right = statusline::build_progress_bar(m.context_pct, 10);
+    statusline::write_tmux_cache(&left, &right);
+}

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -153,6 +153,33 @@ impl Session {
             })
     }
 
+    /// Send a permission response (allow/deny) to the subprocess.
+    ///
+    /// The hook event protocol expects a JSON response on stdin.
+    pub async fn send_permission_response(&self, allowed: bool) -> Result<()> {
+        let behavior = if allowed { "allow" } else { "deny" };
+        let msg = serde_json::json!({
+            "type": "permission_response",
+            "permission_response": {
+                "behavior": behavior
+            }
+        });
+        let line = format!(
+            "{}\n",
+            serde_json::to_string(&msg).map_err(|e| {
+                AclaudeError::Session {
+                    message: format!("failed to serialize permission response: {e}"),
+                }
+            })?
+        );
+        self.stdin_tx
+            .send(line)
+            .await
+            .map_err(|_| AclaudeError::Session {
+                message: "subprocess stdin closed".to_string(),
+            })
+    }
+
     /// Gracefully shut down the subprocess.
     pub async fn shutdown(&mut self) {
         let _ = self.child.kill().await;

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -3,11 +3,9 @@
 //! Spawns `claude` as a headless subprocess with bidirectional NDJSON streaming.
 //! Parses events via `BridgeParser`, updates `SessionMetrics`, and sends events
 //! to consumers via an mpsc channel. The bridge is TUI-agnostic — no ratatui types.
-//!
-//! Both human TUI and future marvel diagnostic view consume the same bridge.
-//! tmux statusline updates happen here so any consumer gets status for free.
 
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
@@ -21,12 +19,26 @@ use crate::protocol_ext::{BridgeEvent, BridgeParser, SessionMetrics};
 use crate::session::find_claude;
 use crate::statusline;
 
+/// Minimum interval between statusline updates (prevents launching
+/// git subprocesses on every streaming text delta).
+const STATUSLINE_INTERVAL_MS: u128 = 2000;
+
 /// A running Claude Code subprocess with event streaming.
 pub struct Session {
     child: Child,
     event_rx: mpsc::Receiver<BridgeEvent>,
     metrics: Arc<Mutex<SessionMetrics>>,
     stdin_tx: mpsc::Sender<String>,
+}
+
+/// Ensure the subprocess is killed if Session is dropped without shutdown().
+impl Drop for Session {
+    fn drop(&mut self) {
+        // Best-effort synchronous kill. The child may already be dead.
+        // We can't .await here, so use start_kill() which sends SIGKILL
+        // without waiting for exit.
+        let _ = self.child.start_kill();
+    }
 }
 
 impl Session {
@@ -82,13 +94,19 @@ impl Session {
             let reader = BufReader::new(stdout);
             let mut lines = reader.lines();
             let mut parser = BridgeParser::new();
+            let mut last_statusline = Instant::now();
             while let Ok(Some(line)) = lines.next_line().await {
                 if line.is_empty() {
                     continue;
                 }
                 if let Some(event) = parser.parse(&line) {
                     update_metrics(&reader_metrics, &event);
-                    push_statusline_from_metrics(&reader_metrics, &statusline_config);
+
+                    // Throttle statusline updates — git subprocess is expensive
+                    if last_statusline.elapsed().as_millis() >= STATUSLINE_INTERVAL_MS {
+                        push_statusline_from_metrics(&reader_metrics, &statusline_config);
+                        last_statusline = Instant::now();
+                    }
 
                     if event_tx.send(event).await.is_err() {
                         break;
@@ -155,7 +173,11 @@ impl Session {
 
     /// Send a permission response (allow/deny) to the subprocess.
     ///
-    /// The hook event protocol expects a JSON response on stdin.
+    /// WARNING: This protocol format is unvalidated against Claude Code's
+    /// actual hook response protocol. The hook system may expect a different
+    /// JSON shape. If the format is wrong, Claude Code will hang waiting
+    /// for a valid response. Needs integration testing before relying on
+    /// permission prompt functionality.
     pub async fn send_permission_response(&self, allowed: bool) -> Result<()> {
         let behavior = if allowed { "allow" } else { "deny" };
         let msg = serde_json::json!({
@@ -191,7 +213,12 @@ impl Session {
 fn update_metrics(metrics: &Arc<Mutex<SessionMetrics>>, event: &BridgeEvent) {
     let mut m = match metrics.lock() {
         Ok(guard) => guard,
-        Err(_) => return,
+        Err(poisoned) => {
+            // Mutex poisoned — a thread panicked while holding the lock.
+            // Recover the guard to prevent silent metric loss.
+            eprintln!("warning: SessionMetrics mutex poisoned, recovering");
+            poisoned.into_inner()
+        }
     };
     match event {
         BridgeEvent::SessionInit {
@@ -213,19 +240,17 @@ fn update_metrics(metrics: &Arc<Mutex<SessionMetrics>>, event: &BridgeEvent) {
         BridgeEvent::Core(ClaudeEvent::System { session_id }) => {
             m.session_id = Some(session_id.clone());
         }
-        BridgeEvent::Core(ClaudeEvent::Assistant { message }) => {
-            if let Some(usage) = &message.usage {
-                m.input_tokens += usage.input_tokens;
-                m.output_tokens += usage.output_tokens;
-                m.cache_read_tokens += usage.cache_read_input_tokens;
-                m.cache_creation_tokens += usage.cache_creation_input_tokens;
-                m.update_context_pct();
-            }
-        }
+        // I1 fix: Do NOT accumulate tokens from partial assistant messages.
+        // With --include-partial-messages, every partial emission includes
+        // usage, and += would massively overcount. Use only the Result event
+        // which has final authoritative usage.
+        BridgeEvent::Core(ClaudeEvent::Assistant { .. }) => {}
         BridgeEvent::Core(ClaudeEvent::Result { payload }) => {
             m.cost_usd = payload.cost_usd;
             m.num_turns = payload.num_turns;
             m.active_tool = None;
+            // Final token counts from the result event
+            // (these are cumulative session totals from Claude Code)
         }
         BridgeEvent::ToolCallStart { name, .. } => {
             m.tool_use_count += 1;
@@ -245,16 +270,18 @@ fn update_metrics(metrics: &Arc<Mutex<SessionMetrics>>, event: &BridgeEvent) {
 }
 
 /// Push tmux statusline from current metrics.
+/// Called at most once per STATUSLINE_INTERVAL_MS to avoid launching
+/// git subprocesses at streaming frequency.
 fn push_statusline_from_metrics(metrics: &Arc<Mutex<SessionMetrics>>, config: &AclaudeConfig) {
     if !config.statusline.enabled {
         return;
     }
     let m = match metrics.lock() {
         Ok(guard) => guard,
-        Err(_) => return,
+        Err(poisoned) => poisoned.into_inner(),
     };
 
-    if m.input_tokens == 0 {
+    if m.input_tokens == 0 && m.cost_usd == 0.0 {
         return;
     }
 

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -1,8 +1,8 @@
 //! Session bridge — async subprocess lifecycle for Claude Code.
 //!
 //! Spawns `claude` as a headless subprocess with bidirectional NDJSON streaming.
-//! Parses events, updates `SessionMetrics`, and sends events to consumers via
-//! an mpsc channel. The bridge is TUI-agnostic — no ratatui types.
+//! Parses events via `BridgeParser`, updates `SessionMetrics`, and sends events
+//! to consumers via an mpsc channel. The bridge is TUI-agnostic — no ratatui types.
 //!
 //! Both human TUI and future marvel diagnostic view consume the same bridge.
 //! tmux statusline updates happen here so any consumer gets status for free.
@@ -17,16 +17,11 @@ use crate::config::AclaudeConfig;
 use crate::error::{AclaudeError, Result};
 use crate::persona;
 use crate::protocol::ClaudeEvent;
-use crate::protocol_ext::{self, BridgeEvent, SessionMetrics};
+use crate::protocol_ext::{BridgeEvent, BridgeParser, SessionMetrics};
 use crate::session::find_claude;
 use crate::statusline;
 
 /// A running Claude Code subprocess with event streaming.
-///
-/// The bridge owns the child process and provides:
-/// - An event receiver (mpsc) for consuming NDJSON events
-/// - Shared metrics via `Arc<Mutex<SessionMetrics>>`
-/// - Methods to send user messages and shut down
 pub struct Session {
     child: Child,
     event_rx: mpsc::Receiver<BridgeEvent>,
@@ -36,12 +31,6 @@ pub struct Session {
 
 impl Session {
     /// Spawn a Claude Code subprocess with NDJSON streaming.
-    ///
-    /// Starts `claude` with `--output-format stream-json --input-format stream-json
-    /// --verbose --include-partial-messages` and the persona system prompt.
-    ///
-    /// Returns a `Session` that produces `BridgeEvent`s via its event receiver
-    /// and accepts user messages via `send_user_message`.
     pub async fn spawn(config: &AclaudeConfig) -> Result<Self> {
         let claude_path = find_claude()?;
 
@@ -56,6 +45,7 @@ impl Session {
             .args(["--input-format", "stream-json"])
             .args(["--verbose"])
             .args(["--include-partial-messages"])
+            .args(["--include-hook-events"])
             .args(["--model", &config.session.model])
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
@@ -85,24 +75,21 @@ impl Session {
         let (event_tx, event_rx) = mpsc::channel::<BridgeEvent>(256);
         let (stdin_tx, mut stdin_rx) = mpsc::channel::<String>(32);
 
-        // Reader task: stdout → parse → metrics update → event channel
+        // Reader task: stdout → BridgeParser → metrics update → event channel
         let reader_metrics = Arc::clone(&metrics);
         let statusline_config = config.clone();
         tokio::spawn(async move {
             let reader = BufReader::new(stdout);
             let mut lines = reader.lines();
+            let mut parser = BridgeParser::new();
             while let Ok(Some(line)) = lines.next_line().await {
                 if line.is_empty() {
                     continue;
                 }
-                if let Some(event) = protocol_ext::parse_bridge_event(&line) {
-                    // Update shared metrics from event data
+                if let Some(event) = parser.parse(&line) {
                     update_metrics(&reader_metrics, &event);
-
-                    // Push tmux statusline (bridge-level, any consumer gets this)
                     push_statusline_from_metrics(&reader_metrics, &statusline_config);
 
-                    // Send to consumer — if channel is full or closed, drop the event
                     if event_tx.send(event).await.is_err() {
                         break;
                     }
@@ -132,25 +119,16 @@ impl Session {
     }
 
     /// Get the event receiver for consuming bridge events.
-    ///
-    /// The receiver yields `BridgeEvent`s as they arrive from the subprocess.
-    /// When the subprocess exits, the channel closes.
     pub fn event_rx(&mut self) -> &mut mpsc::Receiver<BridgeEvent> {
         &mut self.event_rx
     }
 
     /// Get a shared reference to session metrics.
-    ///
-    /// Any consumer can clone this Arc and read metrics independently of
-    /// the event channel. The TUI reads it for the status bar. A future
-    /// marvel sidecar could serialize it to a JSON file.
     pub fn metrics(&self) -> Arc<Mutex<SessionMetrics>> {
         Arc::clone(&self.metrics)
     }
 
     /// Send a user message to the Claude Code subprocess.
-    ///
-    /// Writes the NDJSON user message format to stdin.
     pub async fn send_user_message(&self, text: &str) -> Result<()> {
         let msg = serde_json::json!({
             "type": "user",
@@ -177,8 +155,6 @@ impl Session {
 
     /// Gracefully shut down the subprocess.
     pub async fn shutdown(&mut self) {
-        // Drop the stdin sender to signal EOF
-        // (already dropped when Session is dropped, but explicit is clearer)
         let _ = self.child.kill().await;
         let _ = self.child.wait().await;
     }
@@ -191,24 +167,32 @@ fn update_metrics(metrics: &Arc<Mutex<SessionMetrics>>, event: &BridgeEvent) {
         Err(_) => return,
     };
     match event {
+        BridgeEvent::SessionInit {
+            session_id,
+            permission_mode,
+            available_slash_commands,
+            context_window_size,
+            model,
+            ..
+        } => {
+            m.session_id = Some(session_id.clone());
+            m.permission_mode = permission_mode.clone();
+            m.available_slash_commands = available_slash_commands.clone();
+            m.context_window_size = *context_window_size;
+            if !model.is_empty() {
+                m.model = model.clone();
+            }
+        }
         BridgeEvent::Core(ClaudeEvent::System { session_id }) => {
             m.session_id = Some(session_id.clone());
         }
         BridgeEvent::Core(ClaudeEvent::Assistant { message }) => {
-            // Track tool uses
-            for block in &message.content {
-                if block.block_type == "tool_use" {
-                    m.tool_use_count += 1;
-                    m.active_tool = block.name.clone();
-                }
-            }
-            // Update token counts
             if let Some(usage) = &message.usage {
                 m.input_tokens += usage.input_tokens;
                 m.output_tokens += usage.output_tokens;
                 m.cache_read_tokens += usage.cache_read_input_tokens;
                 m.cache_creation_tokens += usage.cache_creation_input_tokens;
-                m.update_context_pct(200_000);
+                m.update_context_pct();
             }
         }
         BridgeEvent::Core(ClaudeEvent::Result { payload }) => {
@@ -216,22 +200,24 @@ fn update_metrics(metrics: &Arc<Mutex<SessionMetrics>>, event: &BridgeEvent) {
             m.num_turns = payload.num_turns;
             m.active_tool = None;
         }
+        BridgeEvent::ToolCallStart { name, .. } => {
+            m.tool_use_count += 1;
+            m.active_tool = Some(name.clone());
+        }
+        BridgeEvent::ToolCallStop | BridgeEvent::ToolResult { .. } => {
+            m.active_tool = None;
+        }
+        BridgeEvent::ThinkingDelta { text } => {
+            m.thinking_chars += text.len() as u64;
+        }
         BridgeEvent::RateLimit { status, .. } => {
             m.rate_limit_status = Some(status.clone());
-        }
-        BridgeEvent::ToolResult { .. } => {
-            // Tool completed — clear active tool
-            m.active_tool = None;
         }
         _ => {}
     }
 }
 
 /// Push tmux statusline from current metrics.
-///
-/// Continues the pattern from `session.rs` — statusline updates happen at
-/// bridge level so any consumer (TUI, headless, diagnostic) gets tmux
-/// status for free.
 fn push_statusline_from_metrics(metrics: &Arc<Mutex<SessionMetrics>>, config: &AclaudeConfig) {
     if !config.statusline.enabled {
         return;
@@ -241,7 +227,6 @@ fn push_statusline_from_metrics(metrics: &Arc<Mutex<SessionMetrics>>, config: &A
         Err(_) => return,
     };
 
-    // Only update when we have token data
     if m.input_tokens == 0 {
         return;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bridge;
 pub mod config;
 pub mod error;
 pub mod paths;
@@ -5,8 +6,10 @@ pub mod persona;
 pub mod petname;
 pub mod portrait;
 pub mod protocol;
+pub mod protocol_ext;
 pub mod session;
 pub mod session_cmd;
 pub mod statusline;
 pub mod terminal;
+pub mod tui;
 pub mod updater;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use aclaude::persona;
 use aclaude::portrait;
 use aclaude::session;
 use aclaude::session_cmd;
+use aclaude::tui;
 use aclaude::updater;
 use clap::{Parser, Subcommand};
 
@@ -88,6 +89,9 @@ enum Commands {
         #[arg(long)]
         clean: Option<usize>,
     },
+
+    /// Launch interactive TUI (prototype)
+    Tui,
 }
 
 #[derive(Subcommand)]
@@ -427,6 +431,17 @@ fn main() -> anyhow::Result<()> {
             println!("  commit:  {COMMIT}");
             println!("  built:   {BUILD_TIME}");
             println!("  channel: {CHANNEL}");
+        }
+
+        Some(Commands::Tui) => {
+            let cfg = config::load_config(cli_overrides)?;
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| aclaude::error::AclaudeError::Session {
+                    message: format!("failed to create async runtime: {e}"),
+                })?;
+            rt.block_on(tui::run_tui(&cfg))?;
         }
 
         Some(Commands::Versions { clean }) => {

--- a/src/protocol_ext.rs
+++ b/src/protocol_ext.rs
@@ -1,0 +1,227 @@
+//! Extended NDJSON event parsing for the session bridge.
+//!
+//! Wraps the existing `protocol::ClaudeEvent` with additional event types
+//! needed for interactive TUI and diagnostic consumers: streaming text deltas,
+//! tool results, rate limit events, and permission requests.
+//!
+//! This module is TUI-agnostic — no ratatui types. Both human TUI and future
+//! marvel diagnostic view consume these events.
+
+use crate::protocol::{self, ClaudeEvent};
+
+/// Extended event type for the session bridge.
+///
+/// Wraps `ClaudeEvent` with additional event types that the core parser
+/// doesn't handle (streaming deltas, rate limits, permissions).
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum BridgeEvent {
+    /// Core event from the existing protocol parser.
+    Core(ClaudeEvent),
+
+    /// Streaming text chunk from `content_block_delta`.
+    TextDelta { text: String },
+
+    /// Tool result from a `user` type event containing tool_result blocks.
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+    },
+
+    /// Rate limit status change.
+    RateLimit {
+        status: String,
+        resets_at: Option<String>,
+    },
+
+    /// Permission request from Claude Code (tool approval prompt).
+    PermissionRequest { tool: String, description: String },
+}
+
+/// Aggregated session metrics, readable by any consumer.
+///
+/// Updated by the bridge from NDJSON events. The TUI reads this for its
+/// status bar, tmux statusline reads it for the pane status, and a future
+/// marvel sidecar could serialize it to a JSON file for control plane polling.
+#[derive(Debug, Default, Clone)]
+pub struct SessionMetrics {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cost_usd: f64,
+    pub context_pct: f64,
+    pub num_turns: u64,
+    pub tool_use_count: u64,
+    pub active_tool: Option<String>,
+    pub rate_limit_status: Option<String>,
+    pub model: String,
+    pub session_id: Option<String>,
+}
+
+impl SessionMetrics {
+    /// Estimate context window usage percentage.
+    pub fn update_context_pct(&mut self, context_window: u64) {
+        if context_window == 0 {
+            self.context_pct = 0.0;
+        } else {
+            self.context_pct = (self.input_tokens as f64 / context_window as f64) * 100.0;
+        }
+    }
+}
+
+/// Parse a single NDJSON line into a `BridgeEvent`.
+///
+/// Tries the core parser first, then handles additional event types:
+/// - `content_block_delta` → `TextDelta`
+/// - `rate_limit_event` → `RateLimit`
+/// - `user` with tool_result → `ToolResult`
+///
+/// Returns `None` for unparseable lines or empty lines.
+pub fn parse_bridge_event(line: &str) -> Option<BridgeEvent> {
+    if line.is_empty() {
+        return None;
+    }
+
+    let v: serde_json::Value = serde_json::from_str(line).ok()?;
+    let event_type = v.get("type")?.as_str()?;
+
+    // Handle streaming text deltas (partial messages)
+    if event_type == "content_block_delta" {
+        let delta = v.get("delta")?;
+        if delta.get("type").and_then(|t| t.as_str()) == Some("text_delta") {
+            let text = delta.get("text")?.as_str()?.to_string();
+            return Some(BridgeEvent::TextDelta { text });
+        }
+        return None;
+    }
+
+    // Handle rate limit events
+    if event_type == "rate_limit_event" {
+        let status = v
+            .get("status")
+            .and_then(|s| s.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        let resets_at = v
+            .get("resets_at")
+            .and_then(|s| s.as_str())
+            .map(String::from);
+        return Some(BridgeEvent::RateLimit { status, resets_at });
+    }
+
+    // Handle user events with tool results
+    if event_type == "user" {
+        if let Some(message) = v.get("message") {
+            if let Some(content) = message.get("content").and_then(|c| c.as_array()) {
+                for block in content {
+                    if block.get("type").and_then(|t| t.as_str()) == Some("tool_result") {
+                        let tool_use_id = block
+                            .get("tool_use_id")
+                            .and_then(|s| s.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        // Content can be a string or array of blocks
+                        let content_text = if let Some(s) =
+                            block.get("content").and_then(|c| c.as_str())
+                        {
+                            s.to_string()
+                        } else if let Some(arr) = block.get("content").and_then(|c| c.as_array()) {
+                            arr.iter()
+                                .filter_map(|b| {
+                                    if b.get("type").and_then(|t| t.as_str()) == Some("text") {
+                                        b.get("text").and_then(|t| t.as_str()).map(String::from)
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect::<Vec<_>>()
+                                .join("\n")
+                        } else {
+                            String::new()
+                        };
+                        return Some(BridgeEvent::ToolResult {
+                            tool_use_id,
+                            content: content_text,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // Fall through to core parser
+    protocol::parse_event(line).map(BridgeEvent::Core)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_text_delta() {
+        let line = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        match parse_bridge_event(line) {
+            Some(BridgeEvent::TextDelta { text }) => assert_eq!(text, "Hello"),
+            other => panic!("expected TextDelta, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_rate_limit() {
+        let line = r#"{"type":"rate_limit_event","status":"rate_limited","resets_at":"2026-04-10T12:00:00Z"}"#;
+        match parse_bridge_event(line) {
+            Some(BridgeEvent::RateLimit { status, resets_at }) => {
+                assert_eq!(status, "rate_limited");
+                assert_eq!(resets_at.as_deref(), Some("2026-04-10T12:00:00Z"));
+            }
+            other => panic!("expected RateLimit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_tool_result_string_content() {
+        let line = r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"abc123","content":"file contents here"}]}}"#;
+        match parse_bridge_event(line) {
+            Some(BridgeEvent::ToolResult {
+                tool_use_id,
+                content,
+            }) => {
+                assert_eq!(tool_use_id, "abc123");
+                assert_eq!(content, "file contents here");
+            }
+            other => panic!("expected ToolResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_core_system_event() {
+        let line = r#"{"type":"system","session_id":"sess-123","tools":[]}"#;
+        match parse_bridge_event(line) {
+            Some(BridgeEvent::Core(ClaudeEvent::System { session_id })) => {
+                assert_eq!(session_id, "sess-123");
+            }
+            other => panic!("expected Core(System), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_empty_line_returns_none() {
+        assert!(parse_bridge_event("").is_none());
+    }
+
+    #[test]
+    fn parse_invalid_json_returns_none() {
+        assert!(parse_bridge_event("not json").is_none());
+    }
+
+    #[test]
+    fn session_metrics_context_pct() {
+        let mut m = SessionMetrics {
+            input_tokens: 100_000,
+            ..SessionMetrics::default()
+        };
+        m.update_context_pct(200_000);
+        assert!((m.context_pct - 50.0).abs() < 0.01);
+    }
+}

--- a/src/protocol_ext.rs
+++ b/src/protocol_ext.rs
@@ -1,8 +1,8 @@
 //! Extended NDJSON event parsing for the session bridge.
 //!
-//! Wraps the existing `protocol::ClaudeEvent` with additional event types
-//! needed for interactive TUI and diagnostic consumers: streaming text deltas,
-//! tool results, rate limit events, and permission requests.
+//! Provides `BridgeParser`, a stateful parser that handles the full Claude Code
+//! streaming protocol: content blocks, tool calls, thinking blocks, system init,
+//! rate limits, and permission hook events.
 //!
 //! This module is TUI-agnostic — no ratatui types. Both human TUI and future
 //! marvel diagnostic view consume these events.
@@ -10,17 +10,39 @@
 use crate::protocol::{self, ClaudeEvent};
 
 /// Extended event type for the session bridge.
-///
-/// Wraps `ClaudeEvent` with additional event types that the core parser
-/// doesn't handle (streaming deltas, rate limits, permissions).
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum BridgeEvent {
     /// Core event from the existing protocol parser.
     Core(ClaudeEvent),
 
-    /// Streaming text chunk from `content_block_delta`.
+    /// Session initialization with full metadata from system/init.
+    SessionInit {
+        session_id: String,
+        permission_mode: String,
+        available_slash_commands: Vec<String>,
+        context_window_size: u64,
+        model: String,
+        version: String,
+    },
+
+    /// Assistant message started.
+    MessageStart,
+
+    /// Assistant message completed (stop_reason, final usage).
+    MessageStop { stop_reason: String },
+
+    /// Streaming text chunk from `content_block_delta(text_delta)`.
     TextDelta { text: String },
+
+    /// Tool call started — content_block_start(tool_use).
+    ToolCallStart { id: String, name: String },
+
+    /// Streaming tool input JSON fragment.
+    ToolInputDelta { partial_json: String },
+
+    /// Tool call block completed — content_block_stop for a tool.
+    ToolCallStop,
 
     /// Tool result from a `user` type event containing tool_result blocks.
     ToolResult {
@@ -28,21 +50,26 @@ pub enum BridgeEvent {
         content: String,
     },
 
+    /// Thinking block started.
+    ThinkingStart,
+
+    /// Streaming thinking text chunk.
+    ThinkingDelta { text: String },
+
+    /// Thinking block completed.
+    ThinkingStop,
+
     /// Rate limit status change.
     RateLimit {
         status: String,
         resets_at: Option<String>,
     },
 
-    /// Permission request from Claude Code (tool approval prompt).
+    /// Permission request from Claude Code hook event.
     PermissionRequest { tool: String, description: String },
 }
 
 /// Aggregated session metrics, readable by any consumer.
-///
-/// Updated by the bridge from NDJSON events. The TUI reads this for its
-/// status bar, tmux statusline reads it for the pane status, and a future
-/// marvel sidecar could serialize it to a JSON file for control plane polling.
 #[derive(Debug, Default, Clone)]
 pub struct SessionMetrics {
     pub input_tokens: u64,
@@ -53,124 +80,383 @@ pub struct SessionMetrics {
     pub context_pct: f64,
     pub num_turns: u64,
     pub tool_use_count: u64,
+    pub thinking_chars: u64,
     pub active_tool: Option<String>,
     pub rate_limit_status: Option<String>,
     pub model: String,
     pub session_id: Option<String>,
+    pub context_window_size: u64,
+    pub permission_mode: String,
+    pub available_slash_commands: Vec<String>,
 }
 
 impl SessionMetrics {
-    /// Estimate context window usage percentage.
-    pub fn update_context_pct(&mut self, context_window: u64) {
-        if context_window == 0 {
-            self.context_pct = 0.0;
+    /// Update context window usage percentage.
+    pub fn update_context_pct(&mut self) {
+        let window = if self.context_window_size > 0 {
+            self.context_window_size
         } else {
-            self.context_pct = (self.input_tokens as f64 / context_window as f64) * 100.0;
-        }
+            200_000 // fallback
+        };
+        self.context_pct = (self.input_tokens as f64 / window as f64) * 100.0;
     }
 }
 
-/// Parse a single NDJSON line into a `BridgeEvent`.
+/// Stateful NDJSON parser for the Claude Code streaming protocol.
 ///
-/// Tries the core parser first, then handles additional event types:
-/// - `content_block_delta` → `TextDelta`
-/// - `rate_limit_event` → `RateLimit`
-/// - `user` with tool_result → `ToolResult`
-///
-/// Returns `None` for unparseable lines or empty lines.
-pub fn parse_bridge_event(line: &str) -> Option<BridgeEvent> {
-    if line.is_empty() {
-        return None;
+/// Tracks open content blocks across events because `content_block_stop`
+/// does not carry the block type or tool_use_id — the parser must correlate
+/// by remembering what's currently open.
+#[derive(Debug, Default)]
+pub struct BridgeParser {
+    /// Currently open tool call: (tool_use_id, tool_name).
+    pending_tool: Option<(String, String)>,
+    /// Whether a thinking block is currently open.
+    pending_thinking: bool,
+}
+
+impl BridgeParser {
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    let v: serde_json::Value = serde_json::from_str(line).ok()?;
-    let event_type = v.get("type")?.as_str()?;
-
-    // Handle streaming text deltas (partial messages)
-    if event_type == "content_block_delta" {
-        let delta = v.get("delta")?;
-        if delta.get("type").and_then(|t| t.as_str()) == Some("text_delta") {
-            let text = delta.get("text")?.as_str()?.to_string();
-            return Some(BridgeEvent::TextDelta { text });
+    /// Parse a single NDJSON line into a `BridgeEvent`.
+    pub fn parse(&mut self, line: &str) -> Option<BridgeEvent> {
+        if line.is_empty() {
+            return None;
         }
-        return None;
+
+        let v: serde_json::Value = serde_json::from_str(line).ok()?;
+        let event_type = v.get("type")?.as_str()?;
+
+        match event_type {
+            "system" => self.parse_system(&v),
+            "message_start" => Some(BridgeEvent::MessageStart),
+            "message_stop" => Some(BridgeEvent::MessageStop {
+                stop_reason: String::new(),
+            }),
+            "message_delta" => {
+                let stop_reason = v
+                    .get("delta")
+                    .and_then(|d| d.get("stop_reason"))
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                Some(BridgeEvent::MessageStop { stop_reason })
+            }
+            "content_block_start" => self.parse_content_block_start(&v),
+            "content_block_delta" => self.parse_content_block_delta(&v),
+            "content_block_stop" => self.parse_content_block_stop(),
+            "rate_limit_event" => {
+                let status = v
+                    .get("status")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                let resets_at = v
+                    .get("resets_at")
+                    .and_then(|s| s.as_str())
+                    .map(String::from);
+                Some(BridgeEvent::RateLimit { status, resets_at })
+            }
+            "hook_event" => self.parse_hook_event(&v),
+            "user" => Self::parse_user_event(&v),
+            "assistant" | "result" => protocol::parse_event(line).map(BridgeEvent::Core),
+            "ping" => None,
+            _ => protocol::parse_event(line).map(BridgeEvent::Core),
+        }
     }
 
-    // Handle rate limit events
-    if event_type == "rate_limit_event" {
-        let status = v
-            .get("status")
+    fn parse_system(&self, v: &serde_json::Value) -> Option<BridgeEvent> {
+        let subtype = v.get("subtype").and_then(|s| s.as_str()).unwrap_or("");
+
+        if subtype == "init" {
+            let session_id = v
+                .get("session_id")
+                .and_then(|s| s.as_str())
+                .unwrap_or("")
+                .to_string();
+            let permission_mode = v
+                .get("permission_mode")
+                .and_then(|s| s.as_str())
+                .unwrap_or("default")
+                .to_string();
+            let model = v
+                .get("model")
+                .and_then(|s| s.as_str())
+                .unwrap_or("")
+                .to_string();
+            let version = v
+                .get("version")
+                .and_then(|s| s.as_str())
+                .unwrap_or("")
+                .to_string();
+            let context_window_size = v
+                .get("context_window_size")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(200_000);
+            let available_slash_commands = v
+                .get("available_slash_commands")
+                .and_then(|a| a.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|s| s.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            return Some(BridgeEvent::SessionInit {
+                session_id,
+                permission_mode,
+                available_slash_commands,
+                context_window_size,
+                model,
+                version,
+            });
+        }
+
+        // Fall through to core parser for other system subtypes (api_retry, etc.)
+        let session_id = v
+            .get("session_id")
             .and_then(|s| s.as_str())
-            .unwrap_or("unknown")
+            .unwrap_or("")
             .to_string();
-        let resets_at = v
-            .get("resets_at")
-            .and_then(|s| s.as_str())
-            .map(String::from);
-        return Some(BridgeEvent::RateLimit { status, resets_at });
+        Some(BridgeEvent::Core(ClaudeEvent::System { session_id }))
     }
 
-    // Handle user events with tool results
-    if event_type == "user" {
-        if let Some(message) = v.get("message") {
-            if let Some(content) = message.get("content").and_then(|c| c.as_array()) {
-                for block in content {
-                    if block.get("type").and_then(|t| t.as_str()) == Some("tool_result") {
-                        let tool_use_id = block
-                            .get("tool_use_id")
-                            .and_then(|s| s.as_str())
-                            .unwrap_or("")
-                            .to_string();
-                        // Content can be a string or array of blocks
-                        let content_text = if let Some(s) =
-                            block.get("content").and_then(|c| c.as_str())
-                        {
-                            s.to_string()
-                        } else if let Some(arr) = block.get("content").and_then(|c| c.as_array()) {
-                            arr.iter()
-                                .filter_map(|b| {
-                                    if b.get("type").and_then(|t| t.as_str()) == Some("text") {
-                                        b.get("text").and_then(|t| t.as_str()).map(String::from)
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .collect::<Vec<_>>()
-                                .join("\n")
-                        } else {
-                            String::new()
-                        };
-                        return Some(BridgeEvent::ToolResult {
-                            tool_use_id,
-                            content: content_text,
-                        });
-                    }
+    fn parse_content_block_start(&mut self, v: &serde_json::Value) -> Option<BridgeEvent> {
+        let block = v.get("content_block")?;
+        let block_type = block.get("type")?.as_str()?;
+
+        match block_type {
+            "tool_use" => {
+                let id = block
+                    .get("id")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let name = block
+                    .get("name")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                self.pending_tool = Some((id.clone(), name.clone()));
+                Some(BridgeEvent::ToolCallStart { id, name })
+            }
+            "thinking" => {
+                self.pending_thinking = true;
+                Some(BridgeEvent::ThinkingStart)
+            }
+            "text" => None, // text block start carries no useful data
+            _ => None,
+        }
+    }
+
+    fn parse_content_block_delta(&self, v: &serde_json::Value) -> Option<BridgeEvent> {
+        let delta = v.get("delta")?;
+        let delta_type = delta.get("type")?.as_str()?;
+
+        match delta_type {
+            "text_delta" => {
+                let text = delta.get("text")?.as_str()?.to_string();
+                Some(BridgeEvent::TextDelta { text })
+            }
+            "input_json_delta" => {
+                let partial = delta
+                    .get("partial_json")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                Some(BridgeEvent::ToolInputDelta {
+                    partial_json: partial,
+                })
+            }
+            "thinking_delta" => {
+                let text = delta
+                    .get("thinking")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                Some(BridgeEvent::ThinkingDelta { text })
+            }
+            _ => None,
+        }
+    }
+
+    fn parse_content_block_stop(&mut self) -> Option<BridgeEvent> {
+        if self.pending_tool.take().is_some() {
+            return Some(BridgeEvent::ToolCallStop);
+        }
+        if self.pending_thinking {
+            self.pending_thinking = false;
+            return Some(BridgeEvent::ThinkingStop);
+        }
+        // Text block stop — no event needed
+        None
+    }
+
+    fn parse_hook_event(&self, v: &serde_json::Value) -> Option<BridgeEvent> {
+        let subtype = v.get("subtype").and_then(|s| s.as_str())?;
+        if subtype != "PermissionRequest" {
+            return None;
+        }
+        let tool = v
+            .get("tool_name")
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_string();
+        let description = v
+            .get("tool_input")
+            .map(|input| {
+                // Try to get a readable description from tool input
+                if let Some(cmd) = input.get("command").and_then(|s| s.as_str()) {
+                    cmd.to_string()
+                } else if let Some(path) = input.get("file_path").and_then(|s| s.as_str()) {
+                    path.to_string()
+                } else {
+                    serde_json::to_string(input).unwrap_or_default()
                 }
+            })
+            .unwrap_or_default();
+        Some(BridgeEvent::PermissionRequest { tool, description })
+    }
+
+    fn parse_user_event(v: &serde_json::Value) -> Option<BridgeEvent> {
+        let message = v.get("message")?;
+        let content = message.get("content")?.as_array()?;
+        for block in content {
+            if block.get("type").and_then(|t| t.as_str()) == Some("tool_result") {
+                let tool_use_id = block
+                    .get("tool_use_id")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let content_text = if let Some(s) = block.get("content").and_then(|c| c.as_str()) {
+                    s.to_string()
+                } else if let Some(arr) = block.get("content").and_then(|c| c.as_array()) {
+                    arr.iter()
+                        .filter_map(|b| {
+                            if b.get("type").and_then(|t| t.as_str()) == Some("text") {
+                                b.get("text").and_then(|t| t.as_str()).map(String::from)
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                } else {
+                    String::new()
+                };
+                return Some(BridgeEvent::ToolResult {
+                    tool_use_id,
+                    content: content_text,
+                });
             }
         }
+        None
     }
-
-    // Fall through to core parser
-    protocol::parse_event(line).map(BridgeEvent::Core)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn parser() -> BridgeParser {
+        BridgeParser::new()
+    }
+
     #[test]
     fn parse_text_delta() {
+        let mut p = parser();
         let line = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
-        match parse_bridge_event(line) {
+        match p.parse(line) {
             Some(BridgeEvent::TextDelta { text }) => assert_eq!(text, "Hello"),
             other => panic!("expected TextDelta, got {other:?}"),
         }
     }
 
     #[test]
+    fn parse_tool_call_lifecycle() {
+        let mut p = parser();
+
+        // Start
+        let line = r#"{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tool_123","name":"Edit","input":{}}}"#;
+        match p.parse(line) {
+            Some(BridgeEvent::ToolCallStart { id, name }) => {
+                assert_eq!(id, "tool_123");
+                assert_eq!(name, "Edit");
+            }
+            other => panic!("expected ToolCallStart, got {other:?}"),
+        }
+        assert!(p.pending_tool.is_some());
+
+        // Input delta
+        let line = r#"{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"src/"}}"#;
+        match p.parse(line) {
+            Some(BridgeEvent::ToolInputDelta { partial_json }) => {
+                assert_eq!(partial_json, r#"{"path":"src/"#);
+            }
+            other => panic!("expected ToolInputDelta, got {other:?}"),
+        }
+
+        // Stop
+        let line = r#"{"type":"content_block_stop","index":1}"#;
+        match p.parse(line) {
+            Some(BridgeEvent::ToolCallStop) => {}
+            other => panic!("expected ToolCallStop, got {other:?}"),
+        }
+        assert!(p.pending_tool.is_none());
+    }
+
+    #[test]
+    fn parse_thinking_lifecycle() {
+        let mut p = parser();
+
+        let line = r#"{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}"#;
+        assert!(matches!(p.parse(line), Some(BridgeEvent::ThinkingStart)));
+        assert!(p.pending_thinking);
+
+        let line = r#"{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think..."}}"#;
+        match p.parse(line) {
+            Some(BridgeEvent::ThinkingDelta { text }) => {
+                assert_eq!(text, "Let me think...");
+            }
+            other => panic!("expected ThinkingDelta, got {other:?}"),
+        }
+
+        let line = r#"{"type":"content_block_stop","index":0}"#;
+        assert!(matches!(p.parse(line), Some(BridgeEvent::ThinkingStop)));
+        assert!(!p.pending_thinking);
+    }
+
+    #[test]
+    fn parse_session_init() {
+        let mut p = parser();
+        let line = r#"{"type":"system","subtype":"init","session_id":"sess-1","permission_mode":"default","model":"claude-sonnet-4-6","version":"1.0","context_window_size":200000,"available_slash_commands":["/help","/clear"]}"#;
+        match p.parse(line) {
+            Some(BridgeEvent::SessionInit {
+                session_id,
+                permission_mode,
+                model,
+                context_window_size,
+                available_slash_commands,
+                ..
+            }) => {
+                assert_eq!(session_id, "sess-1");
+                assert_eq!(permission_mode, "default");
+                assert_eq!(model, "claude-sonnet-4-6");
+                assert_eq!(context_window_size, 200_000);
+                assert_eq!(available_slash_commands, vec!["/help", "/clear"]);
+            }
+            other => panic!("expected SessionInit, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn parse_rate_limit() {
+        let mut p = parser();
         let line = r#"{"type":"rate_limit_event","status":"rate_limited","resets_at":"2026-04-10T12:00:00Z"}"#;
-        match parse_bridge_event(line) {
+        match p.parse(line) {
             Some(BridgeEvent::RateLimit { status, resets_at }) => {
                 assert_eq!(status, "rate_limited");
                 assert_eq!(resets_at.as_deref(), Some("2026-04-10T12:00:00Z"));
@@ -180,48 +466,90 @@ mod tests {
     }
 
     #[test]
-    fn parse_tool_result_string_content() {
-        let line = r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"abc123","content":"file contents here"}]}}"#;
-        match parse_bridge_event(line) {
+    fn parse_tool_result() {
+        let mut p = parser();
+        let line = r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"abc","content":"result text"}]}}"#;
+        match p.parse(line) {
             Some(BridgeEvent::ToolResult {
                 tool_use_id,
                 content,
             }) => {
-                assert_eq!(tool_use_id, "abc123");
-                assert_eq!(content, "file contents here");
+                assert_eq!(tool_use_id, "abc");
+                assert_eq!(content, "result text");
             }
             other => panic!("expected ToolResult, got {other:?}"),
         }
     }
 
     #[test]
-    fn parse_core_system_event() {
-        let line = r#"{"type":"system","session_id":"sess-123","tools":[]}"#;
-        match parse_bridge_event(line) {
-            Some(BridgeEvent::Core(ClaudeEvent::System { session_id })) => {
-                assert_eq!(session_id, "sess-123");
+    fn parse_message_start_stop() {
+        let mut p = parser();
+        assert!(matches!(
+            p.parse(r#"{"type":"message_start","message":{"id":"msg_1","role":"assistant"}}"#),
+            Some(BridgeEvent::MessageStart)
+        ));
+        assert!(matches!(
+            p.parse(r#"{"type":"message_stop"}"#),
+            Some(BridgeEvent::MessageStop { .. })
+        ));
+    }
+
+    #[test]
+    fn parse_message_delta_with_stop_reason() {
+        let mut p = parser();
+        let line = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":42}}"#;
+        match p.parse(line) {
+            Some(BridgeEvent::MessageStop { stop_reason }) => {
+                assert_eq!(stop_reason, "end_turn");
             }
-            other => panic!("expected Core(System), got {other:?}"),
+            other => panic!("expected MessageStop, got {other:?}"),
         }
     }
 
     #[test]
     fn parse_empty_line_returns_none() {
-        assert!(parse_bridge_event("").is_none());
+        assert!(parser().parse("").is_none());
     }
 
     #[test]
     fn parse_invalid_json_returns_none() {
-        assert!(parse_bridge_event("not json").is_none());
+        assert!(parser().parse("not json").is_none());
     }
 
     #[test]
-    fn session_metrics_context_pct() {
+    fn parse_ping_returns_none() {
+        assert!(parser().parse(r#"{"type":"ping"}"#).is_none());
+    }
+
+    #[test]
+    fn content_block_stop_without_pending_returns_none() {
+        let mut p = parser();
+        // No pending tool or thinking — text block stop
+        assert!(
+            p.parse(r#"{"type":"content_block_stop","index":0}"#)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn session_metrics_context_pct_uses_actual_window() {
         let mut m = SessionMetrics {
-            input_tokens: 100_000,
+            input_tokens: 50_000,
+            context_window_size: 100_000,
             ..SessionMetrics::default()
         };
-        m.update_context_pct(200_000);
+        m.update_context_pct();
         assert!((m.context_pct - 50.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn session_metrics_context_pct_fallback() {
+        let mut m = SessionMetrics {
+            input_tokens: 100_000,
+            context_window_size: 0, // unset
+            ..SessionMetrics::default()
+        };
+        m.update_context_pct();
+        assert!((m.context_pct - 50.0).abs() < 0.01); // falls back to 200k
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -442,6 +442,23 @@ impl AppState {
             None
         }
     }
+
+    /// Toggle is_expanded on the most recent completed tool call.
+    pub fn toggle_last_tool_expand(&mut self) {
+        // Search backward through all turns for the last completed tool
+        for item in self.items.iter_mut().rev() {
+            if let ConversationItem::AssistantTurn { blocks, .. } = item {
+                for block in blocks.iter_mut().rev() {
+                    if let TurnBlock::ToolCall(tool) = block {
+                        if matches!(tool.status, ToolStatus::Complete { .. }) {
+                            tool.is_expanded = !tool.is_expanded;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 // ── Rendering ────────────────────────────────────────────────────────────
@@ -572,7 +589,7 @@ pub fn render_conversation(frame: &mut Frame, state: &mut AppState, area: Rect) 
     frame.render_widget(paragraph, area);
 }
 
-/// Render a single tool call line in the conversation.
+/// Render a tool call block in the conversation.
 fn render_tool_call_line(lines: &mut Vec<Line>, tool: &ToolCallItem, frame_count: u64) {
     let elapsed = tool.started_at.elapsed().as_secs_f64();
 
@@ -606,28 +623,20 @@ fn render_tool_call_line(lines: &mut Vec<Line>, tool: &ToolCallItem, frame_count
             ]));
         }
         ToolStatus::Complete { elapsed_secs } => {
-            let preview: String = if tool.result_preview.is_empty() {
-                "done".to_string()
-            } else {
-                tool.result_preview
-                    .lines()
-                    .next()
-                    .unwrap_or("")
-                    .chars()
-                    .take(60)
-                    .collect()
-            };
+            // Header line with status
             lines.push(Line::from(vec![
                 Span::styled(
                     format!("  ✓ {} ", tool.name),
                     Style::default().fg(Color::Green),
                 ),
                 Span::styled(
-                    format!("[{elapsed_secs:.1}s] "),
+                    format!("[{elapsed_secs:.1}s]"),
                     Style::default().fg(Color::DarkGray),
                 ),
-                Span::styled(preview, Style::default().fg(Color::DarkGray)),
             ]));
+            // Rich tool call rendering (diff, file content, command output)
+            let detail_lines = super::diff::render_tool_call(tool);
+            lines.extend(detail_lines);
         }
         ToolStatus::Error { message } => {
             lines.push(Line::from(vec![

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -136,15 +136,17 @@ pub enum AppStatus {
 
 impl AppStatus {
     /// Whether the input field should accept typed characters.
+    /// Permissive — only blocks on fatal error. The user should always
+    /// be able to type; the subprocess accepts input regardless of state.
     pub fn accepts_input(self) -> bool {
-        self == Self::Ready
+        self != Self::Error
     }
 
-    /// Spinner character for non-ready states.
+    /// Spinner character for active states.
     pub fn spinner(self, frame_count: u64) -> Option<&'static str> {
         const FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
         match self {
-            Self::Connecting | Self::Thinking | Self::Streaming | Self::ToolRunning => {
+            Self::Thinking | Self::Streaming | Self::ToolRunning => {
                 Some(FRAMES[(frame_count as usize) % FRAMES.len()])
             }
             _ => None,
@@ -332,6 +334,11 @@ impl AppState {
 
     /// Apply a bridge event to update state.
     pub fn apply_event(&mut self, event: &BridgeEvent) {
+        // Any event arriving means we're connected
+        if self.status == AppStatus::Connecting {
+            self.status = AppStatus::Ready;
+        }
+
         match event {
             BridgeEvent::SessionInit {
                 available_slash_commands,
@@ -342,12 +349,7 @@ impl AppState {
                 self.available_slash_commands = available_slash_commands.clone();
                 self.permission_mode = PermissionMode::parse_mode(permission_mode);
             }
-            BridgeEvent::Core(ClaudeEvent::System { .. }) => {
-                // Legacy system event without init subtype
-                if self.status == AppStatus::Connecting {
-                    self.status = AppStatus::Ready;
-                }
-            }
+            BridgeEvent::Core(ClaudeEvent::System { .. }) => {}
             BridgeEvent::MessageStart => {
                 self.status = AppStatus::Thinking;
                 self.ensure_active_turn();
@@ -909,8 +911,7 @@ fn render_tool_call_line(lines: &mut Vec<Line>, tool: &ToolCallItem, frame_count
 /// Render the input area.
 pub fn render_input(frame: &mut Frame, state: &AppState, area: Rect) {
     let placeholder = match state.status {
-        AppStatus::Connecting => "Connecting...",
-        AppStatus::Ready => "Type a message...",
+        AppStatus::Connecting | AppStatus::Ready => "Type a message...",
         AppStatus::Thinking | AppStatus::Streaming | AppStatus::ToolRunning => "Waiting...",
         AppStatus::Error => "Error — press Ctrl+C to exit",
     };

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -40,6 +40,25 @@ impl PortraitSize {
     }
 }
 
+/// Portrait position in the conversation viewport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PortraitPosition {
+    /// Upper-right corner of conversation area.
+    TopRight,
+    /// Lower-right corner, just above the input area.
+    BottomRight,
+}
+
+impl PortraitPosition {
+    /// Toggle between top and bottom.
+    pub fn toggle(self) -> Self {
+        match self {
+            Self::TopRight => Self::BottomRight,
+            Self::BottomRight => Self::TopRight,
+        }
+    }
+}
+
 /// Application status — drives visual feedback and input gating.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AppStatus {
@@ -201,6 +220,10 @@ pub struct AppState {
     pub input_buffer: String,
     /// Portrait size setting.
     pub portrait_size: PortraitSize,
+    /// Whether the portrait is visible.
+    pub portrait_visible: bool,
+    /// Portrait position (top-right or bottom-right).
+    pub portrait_position: PortraitPosition,
     /// Shared metrics from bridge.
     pub metrics: Arc<Mutex<SessionMetrics>>,
     /// Current application status.
@@ -229,6 +252,8 @@ impl AppState {
             items: Vec::new(),
             input_buffer: String::new(),
             portrait_size: PortraitSize::Medium,
+            portrait_visible: true,
+            portrait_position: PortraitPosition::TopRight,
             metrics,
             status: AppStatus::Connecting,
             scroll: ScrollState::default(),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -676,13 +676,25 @@ pub fn render_conversation(frame: &mut Frame, state: &mut AppState, area: Rect) 
                                 } else {
                                     format!("{}", content.len())
                                 };
-                                let label = if *is_streaming {
-                                    format!("▸ Thinking ({char_count} chars)...")
+                                if *is_streaming {
+                                    let spinner =
+                                        state.status.spinner(state.frame_count).unwrap_or("⠋");
+                                    lines.push(Line::from(Span::styled(
+                                        format!("  {spinner} Thinking ({char_count} chars)..."),
+                                        Style::default().fg(Color::DarkGray),
+                                    )));
                                 } else {
-                                    format!("▸ Thinking ({char_count} chars)")
-                                };
+                                    lines.push(Line::from(Span::styled(
+                                        format!("  ▸ Thinking ({char_count} chars)"),
+                                        Style::default().fg(Color::DarkGray),
+                                    )));
+                                }
+                            } else if *is_streaming {
+                                // Thinking just started, no content yet
+                                let spinner =
+                                    state.status.spinner(state.frame_count).unwrap_or("⠋");
                                 lines.push(Line::from(Span::styled(
-                                    label,
+                                    format!("  {spinner} Thinking..."),
                                     Style::default().fg(Color::DarkGray),
                                 )));
                             }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,0 +1,354 @@
+//! TUI application state and rendering.
+//!
+//! `AppState` owns the conversation history, streaming state, and input buffer.
+//! Render functions draw the conversation viewport, input area, and status bar.
+//! Metrics are read from the shared bridge `Arc<Mutex<SessionMetrics>>`.
+
+use std::sync::{Arc, Mutex};
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+use super::scroll::ScrollState;
+use crate::protocol::ClaudeEvent;
+use crate::protocol_ext::{BridgeEvent, SessionMetrics};
+
+/// Portrait size options.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PortraitSize {
+    Small,
+    Medium,
+    Large,
+    Original,
+}
+
+impl PortraitSize {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "small" => Some(Self::Small),
+            "medium" => Some(Self::Medium),
+            "large" => Some(Self::Large),
+            "original" => Some(Self::Original),
+            _ => None,
+        }
+    }
+}
+
+/// A message in the conversation history.
+#[derive(Debug)]
+pub struct Message {
+    pub role: MessageRole,
+    pub text: String,
+}
+
+#[derive(Debug)]
+pub enum MessageRole {
+    User,
+    Assistant,
+    System,
+}
+
+/// A tool call entry for display.
+#[derive(Debug)]
+pub struct ToolCallEntry {
+    pub name: String,
+    pub status: ToolStatus,
+}
+
+#[derive(Debug)]
+pub enum ToolStatus {
+    Running,
+    Complete,
+}
+
+/// Application state for the TUI.
+pub struct AppState {
+    /// Conversation history.
+    pub messages: Vec<Message>,
+    /// Current streaming text (partial response being assembled).
+    pub streaming_text: String,
+    /// Tool calls in the current turn.
+    pub tool_calls: Vec<ToolCallEntry>,
+    /// User input buffer.
+    pub input_buffer: String,
+    /// Portrait size setting.
+    pub portrait_size: PortraitSize,
+    /// Shared metrics from bridge.
+    pub metrics: Arc<Mutex<SessionMetrics>>,
+    /// Whether we're waiting for the first response after sending.
+    pub is_waiting: bool,
+    /// Scroll state for the conversation viewport.
+    pub scroll: ScrollState,
+    /// Status message (rate limit notices, errors).
+    pub status_message: Option<String>,
+}
+
+impl AppState {
+    pub fn new(metrics: Arc<Mutex<SessionMetrics>>) -> Self {
+        Self {
+            messages: Vec::new(),
+            streaming_text: String::new(),
+            tool_calls: Vec::new(),
+            input_buffer: String::new(),
+            portrait_size: PortraitSize::Medium,
+            metrics,
+            is_waiting: false,
+            scroll: ScrollState::default(),
+            status_message: None,
+        }
+    }
+
+    /// Apply a bridge event to update state.
+    pub fn apply_event(&mut self, event: &BridgeEvent) {
+        match event {
+            BridgeEvent::TextDelta { text } => {
+                self.is_waiting = false;
+                self.streaming_text.push_str(text);
+            }
+            BridgeEvent::Core(ClaudeEvent::Assistant { message }) => {
+                self.is_waiting = false;
+                // If we have accumulated streaming text and this is a complete
+                // message, commit it
+                for block in &message.content {
+                    match block.block_type.as_str() {
+                        "text" => {
+                            if let Some(text) = &block.text {
+                                // If streaming text matches, it's already accumulated.
+                                // If not (non-streaming mode), use the block text.
+                                if self.streaming_text.is_empty() {
+                                    self.streaming_text.push_str(text);
+                                }
+                            }
+                        }
+                        "tool_use" => {
+                            if let Some(name) = &block.name {
+                                self.tool_calls.push(ToolCallEntry {
+                                    name: name.clone(),
+                                    status: ToolStatus::Running,
+                                });
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            BridgeEvent::ToolResult { .. } => {
+                // Mark the last running tool as complete
+                if let Some(last) = self.tool_calls.last_mut() {
+                    if matches!(last.status, ToolStatus::Running) {
+                        last.status = ToolStatus::Complete;
+                    }
+                }
+            }
+            BridgeEvent::Core(ClaudeEvent::Result { .. }) => {
+                // Session ended — commit any remaining streaming text
+                self.commit_streaming_text();
+                self.is_waiting = false;
+            }
+            BridgeEvent::RateLimit { status, .. } => {
+                self.status_message = Some(format!("Rate limit: {status}"));
+            }
+            BridgeEvent::Core(ClaudeEvent::System { .. }) => {}
+            _ => {}
+        }
+    }
+
+    /// Commit accumulated streaming text as an assistant message.
+    pub fn commit_streaming_text(&mut self) {
+        if !self.streaming_text.is_empty() {
+            let text = std::mem::take(&mut self.streaming_text);
+            self.messages.push(Message {
+                role: MessageRole::Assistant,
+                text,
+            });
+            self.tool_calls.clear();
+        }
+    }
+
+    /// Record a sent user message.
+    pub fn record_user_message(&mut self, text: String) {
+        // Commit any previous assistant response
+        self.commit_streaming_text();
+        self.messages.push(Message {
+            role: MessageRole::User,
+            text,
+        });
+        self.is_waiting = true;
+    }
+}
+
+/// Render the conversation viewport.
+pub fn render_conversation(frame: &mut Frame, state: &mut AppState, area: Rect) {
+    let mut lines: Vec<Line> = Vec::new();
+
+    // Render committed messages
+    for msg in &state.messages {
+        let (prefix, style) = match msg.role {
+            MessageRole::User => (
+                "You: ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            MessageRole::Assistant => ("", Style::default().fg(Color::White)),
+            MessageRole::System => ("System: ", Style::default().fg(Color::Yellow)),
+        };
+
+        lines.push(Line::from(vec![Span::styled(prefix, style)]));
+        for text_line in msg.text.lines() {
+            lines.push(Line::from(Span::styled(text_line.to_string(), style)));
+        }
+        lines.push(Line::from(""));
+    }
+
+    // Render active tool calls
+    for tool in &state.tool_calls {
+        let indicator = match tool.status {
+            ToolStatus::Running => "⟳",
+            ToolStatus::Complete => "✓",
+        };
+        lines.push(Line::from(Span::styled(
+            format!("  {indicator} {}", tool.name),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    // Render streaming text
+    if !state.streaming_text.is_empty() {
+        for text_line in state.streaming_text.lines() {
+            lines.push(Line::from(Span::styled(
+                text_line.to_string(),
+                Style::default().fg(Color::White),
+            )));
+        }
+        // Streaming cursor
+        lines.push(Line::from(Span::styled(
+            "▌",
+            Style::default().fg(Color::Green),
+        )));
+    }
+
+    // Waiting indicator
+    if state.is_waiting {
+        lines.push(Line::from(Span::styled(
+            "Thinking...",
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::ITALIC),
+        )));
+    }
+
+    let text = Text::from(lines.clone());
+    let content_height = text.height() as u16;
+    state
+        .scroll
+        .set_viewport_height(area.height.saturating_sub(2)); // account for borders
+    state.scroll.set_content_height(content_height);
+
+    let paragraph = Paragraph::new(text)
+        .block(Block::default().borders(Borders::ALL).title(" aclaude "))
+        .wrap(Wrap { trim: false })
+        .scroll((state.scroll.offset, 0));
+
+    frame.render_widget(paragraph, area);
+}
+
+/// Render the input area.
+pub fn render_input(frame: &mut Frame, state: &AppState, area: Rect) {
+    let display_text = if state.input_buffer.is_empty() {
+        Span::styled("Type a message...", Style::default().fg(Color::DarkGray))
+    } else {
+        Span::styled(
+            state.input_buffer.as_str(),
+            Style::default().fg(Color::White),
+        )
+    };
+
+    let input = Paragraph::new(Line::from(vec![
+        Span::styled("> ", Style::default().fg(Color::Green)),
+        display_text,
+    ]))
+    .block(Block::default().borders(Borders::ALL));
+
+    frame.render_widget(input, area);
+}
+
+/// Render the status bar.
+pub fn render_status(frame: &mut Frame, state: &AppState, area: Rect) {
+    let m = state
+        .metrics
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    let mut parts: Vec<Span> = Vec::new();
+
+    // Model
+    if !m.model.is_empty() {
+        parts.push(Span::styled(
+            m.model.clone(),
+            Style::default().fg(Color::DarkGray),
+        ));
+        parts.push(Span::raw(" │ "));
+    }
+
+    // Tokens
+    parts.push(Span::styled(
+        format!("{}↓ {}↑", m.input_tokens, m.output_tokens),
+        Style::default().fg(Color::DarkGray),
+    ));
+
+    // Cost
+    if m.cost_usd > 0.0 {
+        parts.push(Span::raw(" │ "));
+        parts.push(Span::styled(
+            format!("${:.4}", m.cost_usd),
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
+
+    // Context %
+    if m.context_pct > 0.0 {
+        parts.push(Span::raw(" │ "));
+        let color = if m.context_pct > 90.0 {
+            Color::Red
+        } else if m.context_pct > 70.0 {
+            Color::Yellow
+        } else {
+            Color::Green
+        };
+        parts.push(Span::styled(
+            format!("ctx {:.0}%", m.context_pct),
+            Style::default().fg(color),
+        ));
+    }
+
+    // Active tool
+    if let Some(tool) = &m.active_tool {
+        parts.push(Span::raw(" │ "));
+        parts.push(Span::styled(
+            format!("⟳ {tool}"),
+            Style::default().fg(Color::Cyan),
+        ));
+    }
+
+    // Rate limit
+    if let Some(rl) = &m.rate_limit_status {
+        parts.push(Span::raw(" │ "));
+        parts.push(Span::styled(rl.clone(), Style::default().fg(Color::Red)));
+    }
+
+    // Status message
+    if let Some(msg) = &state.status_message {
+        parts.push(Span::raw(" │ "));
+        parts.push(Span::styled(
+            msg.clone(),
+            Style::default().fg(Color::Yellow),
+        ));
+    }
+
+    let status = Paragraph::new(Line::from(parts));
+    frame.render_widget(status, area);
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -38,6 +38,25 @@ impl PortraitSize {
             _ => None,
         }
     }
+
+    /// Cycle to the next size.
+    pub fn next(self) -> Self {
+        match self {
+            Self::Small => Self::Medium,
+            Self::Medium => Self::Large,
+            Self::Large => Self::Original,
+            Self::Original => Self::Small,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Small => "small",
+            Self::Medium => "medium",
+            Self::Large => "large",
+            Self::Original => "original",
+        }
+    }
 }
 
 /// Portrait position in the conversation viewport.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -934,9 +934,10 @@ pub fn render_input(frame: &mut Frame, state: &AppState, area: Rect) {
 
     frame.render_widget(input, area);
 
-    // Position cursor accounting for text wrapping
-    // +2 for "> " prefix
-    let inner_width = area.width.saturating_sub(2); // inside borders (no left/right borders but paragraph padding)
+    // Position cursor accounting for text wrapping.
+    // No left/right borders — inner width equals area width.
+    // +2 for "> " prefix.
+    let inner_width = area.width;
     let char_pos = state.input.cursor as u16 + 2; // +2 for "> "
     let (cursor_x, cursor_y) = if inner_width == 0 {
         (area.x, area.y + 1)

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -929,15 +929,26 @@ pub fn render_input(frame: &mut Frame, state: &AppState, area: Rect) {
         Span::styled("> ", Style::default().fg(Color::Green)),
         display_text,
     ]))
-    .block(Block::default().borders(Borders::TOP | Borders::BOTTOM));
+    .block(Block::default().borders(Borders::TOP | Borders::BOTTOM))
+    .wrap(Wrap { trim: false });
 
     frame.render_widget(input, area);
 
-    // Position cursor at the InputState cursor position
-    // +1 for top border, +2 for "> " prefix
-    let cursor_x = area.x + 2 + state.input.cursor as u16;
-    let cursor_y = area.y + 1;
-    frame.set_cursor_position((cursor_x.min(area.x + area.width - 1), cursor_y));
+    // Position cursor accounting for text wrapping
+    // +2 for "> " prefix
+    let inner_width = area.width.saturating_sub(2); // inside borders (no left/right borders but paragraph padding)
+    let char_pos = state.input.cursor as u16 + 2; // +2 for "> "
+    let (cursor_x, cursor_y) = if inner_width == 0 {
+        (area.x, area.y + 1)
+    } else {
+        let line_num = char_pos / inner_width;
+        let col = char_pos % inner_width;
+        (area.x + col, area.y + 1 + line_num) // +1 for top border
+    };
+    frame.set_cursor_position((
+        cursor_x.min(area.x + area.width - 1),
+        cursor_y.min(area.y + area.height - 1),
+    ));
 }
 
 /// Render the status bar.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -78,6 +78,45 @@ impl PortraitPosition {
     }
 }
 
+/// Transcript/view mode — cycled via Ctrl+O.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TranscriptMode {
+    /// Normal TUI rendering in alternate screen.
+    #[default]
+    Normal,
+    /// Dump conversation to native terminal scrollback.
+    Transcript,
+    /// Distraction-free: hide status bar and input borders.
+    Focus,
+}
+
+impl TranscriptMode {
+    pub fn next(self) -> Self {
+        match self {
+            Self::Normal => Self::Transcript,
+            Self::Transcript => Self::Focus,
+            Self::Focus => Self::Normal,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Normal => "normal",
+            Self::Transcript => "transcript",
+            Self::Focus => "focus",
+        }
+    }
+}
+
+/// A diagnostic entry (placeholder for future LSP integration).
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct DiagnosticEntry {
+    pub file: String,
+    pub line: u32,
+    pub message: String,
+}
+
 /// Application status — drives visual feedback and input gating.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AppStatus {
@@ -152,6 +191,8 @@ pub struct ToolCallItem {
     pub status: ToolStatus,
     pub started_at: Instant,
     pub is_expanded: bool,
+    /// Diagnostics (placeholder — empty until LSP wired).
+    pub diagnostics: Vec<DiagnosticEntry>,
 }
 
 /// Tool execution status.
@@ -263,6 +304,8 @@ pub struct AppState {
     pub pending_permission: Option<PermissionPrompt>,
     /// When the status message was set (for auto-clear after timeout).
     pub status_message_at: Option<Instant>,
+    /// Current transcript/view mode.
+    pub transcript_mode: TranscriptMode,
 }
 
 impl AppState {
@@ -283,6 +326,7 @@ impl AppState {
             permission_mode: PermissionMode::Default,
             pending_permission: None,
             status_message_at: None,
+            transcript_mode: TranscriptMode::default(),
         }
     }
 
@@ -326,6 +370,7 @@ impl AppState {
                         status: ToolStatus::InputStreaming,
                         started_at: Instant::now(),
                         is_expanded: false,
+                        diagnostics: Vec::new(),
                     }));
                 }
             }
@@ -413,6 +458,7 @@ impl AppState {
                                         status: ToolStatus::Running,
                                         started_at: Instant::now(),
                                         is_expanded: false,
+                                        diagnostics: Vec::new(),
                                     }));
                                 }
                             }
@@ -577,6 +623,62 @@ impl AppState {
                 self.status_message_at = None;
             }
         }
+    }
+
+    /// Render conversation as plain text for transcript dump.
+    pub fn conversation_as_text(&self) -> String {
+        let mut output = String::new();
+        for item in &self.items {
+            match item {
+                ConversationItem::UserMessage { text } => {
+                    output.push_str("You: ");
+                    output.push_str(text);
+                    output.push_str("\n\n");
+                }
+                ConversationItem::AssistantTurn { blocks, .. } => {
+                    for block in blocks {
+                        match block {
+                            TurnBlock::Text { content, .. } => {
+                                output.push_str(content);
+                                output.push('\n');
+                            }
+                            TurnBlock::ToolCall(tool) => {
+                                output.push_str(&format!(
+                                    "  [{} {}]\n",
+                                    match &tool.status {
+                                        ToolStatus::Complete { .. } => "✓",
+                                        ToolStatus::Error { .. } => "✗",
+                                        _ => "⟳",
+                                    },
+                                    tool.name
+                                ));
+                                if !tool.result_preview.is_empty() {
+                                    output.push_str(&format!(
+                                        "    {}\n",
+                                        tool.result_preview.lines().next().unwrap_or("")
+                                    ));
+                                }
+                            }
+                            TurnBlock::Thinking { content, .. } => {
+                                if !content.is_empty() {
+                                    output.push_str(&format!(
+                                        "  [Thinking: {} chars]\n",
+                                        content.len()
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                    output.push('\n');
+                }
+                ConversationItem::SystemNotice { text } => {
+                    output.push_str("System: ");
+                    output.push_str(text);
+                    output.push_str("\n\n");
+                }
+            }
+        }
+        output
     }
 
     /// Toggle is_expanded on the most recent completed tool call.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -938,7 +938,8 @@ pub fn render_input(frame: &mut Frame, state: &AppState, area: Rect) {
     // No left/right borders — inner width equals area width.
     // +2 for "> " prefix.
     let inner_width = area.width;
-    let char_pos = state.input.cursor as u16 + 2; // +2 for "> "
+    let capped_cursor = state.input.cursor.min(u16::MAX as usize - 2) as u16;
+    let char_pos = capped_cursor + 2; // +2 for "> "
     let (cursor_x, cursor_y) = if inner_width == 0 {
         (area.x, area.y + 1)
     } else {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,10 +1,11 @@
 //! TUI application state and rendering.
 //!
-//! `AppState` owns the conversation history, streaming state, and input buffer.
-//! Render functions draw the conversation viewport, input area, and status bar.
-//! Metrics are read from the shared bridge `Arc<Mutex<SessionMetrics>>`.
+//! `AppState` owns the conversation as a structured turn model, driven by
+//! an `AppStatus` state machine. Render functions draw the conversation
+//! viewport, input area, and status bar using a `RenderCtx` for purity.
 
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -15,6 +16,8 @@ use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 use super::scroll::ScrollState;
 use crate::protocol::ClaudeEvent;
 use crate::protocol_ext::{BridgeEvent, SessionMetrics};
+
+// ── Types ────────────────────────────────────────────────────────────────
 
 /// Portrait size options.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -37,211 +40,527 @@ impl PortraitSize {
     }
 }
 
-/// A message in the conversation history.
-#[derive(Debug)]
-pub struct Message {
-    pub role: MessageRole,
-    pub text: String,
+/// Application status — drives visual feedback and input gating.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppStatus {
+    /// Waiting for system/init from subprocess.
+    Connecting,
+    /// Idle, accepting user input.
+    Ready,
+    /// Assistant turn started, no content yet.
+    Thinking,
+    /// Text deltas arriving.
+    Streaming,
+    /// Tool call in progress.
+    ToolRunning,
+    /// Fatal error.
+    Error,
 }
 
-#[derive(Debug)]
-pub enum MessageRole {
-    User,
-    Assistant,
-    System,
+impl AppStatus {
+    /// Whether the input field should accept typed characters.
+    pub fn accepts_input(self) -> bool {
+        self == Self::Ready
+    }
+
+    /// Spinner character for non-ready states.
+    pub fn spinner(self, frame_count: u64) -> Option<&'static str> {
+        const FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+        match self {
+            Self::Connecting | Self::Thinking | Self::Streaming | Self::ToolRunning => {
+                Some(FRAMES[(frame_count as usize) % FRAMES.len()])
+            }
+            _ => None,
+        }
+    }
 }
 
-/// A tool call entry for display.
+// ── Conversation Model ───────────────────────────────────────────────────
+
+/// A single item in the conversation.
 #[derive(Debug)]
-pub struct ToolCallEntry {
+pub enum ConversationItem {
+    /// User-sent message.
+    UserMessage { text: String },
+    /// One assistant turn (may contain text, tool calls, thinking).
+    AssistantTurn {
+        blocks: Vec<TurnBlock>,
+        is_active: bool,
+    },
+    /// Synthetic system notice (compact markers, errors).
+    SystemNotice { text: String },
+}
+
+/// A block within an assistant turn.
+#[derive(Debug)]
+pub enum TurnBlock {
+    /// Text content (streaming or committed).
+    Text { content: String, is_streaming: bool },
+    /// A tool call with lifecycle tracking.
+    ToolCall(ToolCallItem),
+    /// A thinking block (streaming or committed).
+    Thinking { content: String, is_streaming: bool },
+}
+
+/// Tool call lifecycle state.
+#[derive(Debug)]
+pub struct ToolCallItem {
+    pub id: String,
     pub name: String,
+    /// Accumulated input_json_delta chunks.
+    pub input_json: String,
+    /// First 200 chars of tool result.
+    pub result_preview: String,
     pub status: ToolStatus,
+    pub started_at: Instant,
+    pub is_expanded: bool,
 }
 
+/// Tool execution status.
 #[derive(Debug)]
 pub enum ToolStatus {
+    /// Input JSON still arriving via deltas.
+    InputStreaming,
+    /// Tool executing (content_block_stop seen, awaiting result).
     Running,
-    Complete,
+    /// Tool completed successfully.
+    Complete { elapsed_secs: f64 },
+    /// Tool errored.
+    Error { message: String },
 }
+
+// ── App State ────────────────────────────────────────────────────────────
 
 /// Application state for the TUI.
 pub struct AppState {
-    /// Conversation history.
-    pub messages: Vec<Message>,
-    /// Current streaming text (partial response being assembled).
-    pub streaming_text: String,
-    /// Tool calls in the current turn.
-    pub tool_calls: Vec<ToolCallEntry>,
+    /// Structured conversation history.
+    pub items: Vec<ConversationItem>,
     /// User input buffer.
     pub input_buffer: String,
     /// Portrait size setting.
     pub portrait_size: PortraitSize,
     /// Shared metrics from bridge.
     pub metrics: Arc<Mutex<SessionMetrics>>,
-    /// Whether we're waiting for the first response after sending.
-    pub is_waiting: bool,
+    /// Current application status.
+    pub status: AppStatus,
     /// Scroll state for the conversation viewport.
     pub scroll: ScrollState,
     /// Status message (rate limit notices, errors).
     pub status_message: Option<String>,
+    /// Available slash commands from system/init.
+    pub available_slash_commands: Vec<String>,
+    /// Whether to show thinking blocks.
+    pub show_thinking: bool,
+    /// Frame counter for spinner animation.
+    pub frame_count: u64,
 }
 
 impl AppState {
     pub fn new(metrics: Arc<Mutex<SessionMetrics>>) -> Self {
         Self {
-            messages: Vec::new(),
-            streaming_text: String::new(),
-            tool_calls: Vec::new(),
+            items: Vec::new(),
             input_buffer: String::new(),
             portrait_size: PortraitSize::Medium,
             metrics,
-            is_waiting: false,
+            status: AppStatus::Connecting,
             scroll: ScrollState::default(),
             status_message: None,
+            available_slash_commands: Vec::new(),
+            show_thinking: false,
+            frame_count: 0,
         }
     }
 
     /// Apply a bridge event to update state.
     pub fn apply_event(&mut self, event: &BridgeEvent) {
         match event {
+            BridgeEvent::SessionInit {
+                available_slash_commands,
+                ..
+            } => {
+                self.status = AppStatus::Ready;
+                self.available_slash_commands = available_slash_commands.clone();
+            }
+            BridgeEvent::Core(ClaudeEvent::System { .. }) => {
+                // Legacy system event without init subtype
+                if self.status == AppStatus::Connecting {
+                    self.status = AppStatus::Ready;
+                }
+            }
+            BridgeEvent::MessageStart => {
+                self.status = AppStatus::Thinking;
+                self.ensure_active_turn();
+            }
             BridgeEvent::TextDelta { text } => {
-                self.is_waiting = false;
-                self.streaming_text.push_str(text);
+                self.status = AppStatus::Streaming;
+                self.append_streaming_text(text);
+            }
+            BridgeEvent::ToolCallStart { id, name } => {
+                self.status = AppStatus::ToolRunning;
+                self.commit_streaming_text();
+                self.ensure_active_turn();
+                if let Some(ConversationItem::AssistantTurn { blocks, .. }) = self.items.last_mut()
+                {
+                    blocks.push(TurnBlock::ToolCall(ToolCallItem {
+                        id: id.clone(),
+                        name: name.clone(),
+                        input_json: String::new(),
+                        result_preview: String::new(),
+                        status: ToolStatus::InputStreaming,
+                        started_at: Instant::now(),
+                        is_expanded: false,
+                    }));
+                }
+            }
+            BridgeEvent::ToolInputDelta { partial_json } => {
+                if let Some(tool) = self.last_tool_mut() {
+                    tool.input_json.push_str(partial_json);
+                }
+            }
+            BridgeEvent::ToolCallStop => {
+                if let Some(tool) = self.last_tool_mut() {
+                    tool.status = ToolStatus::Running;
+                }
+            }
+            BridgeEvent::ToolResult {
+                tool_use_id,
+                content,
+            } => {
+                // Find tool by id and mark complete
+                if let Some(tool) = self.find_tool_mut(tool_use_id) {
+                    let elapsed = tool.started_at.elapsed().as_secs_f64();
+                    tool.status = ToolStatus::Complete {
+                        elapsed_secs: elapsed,
+                    };
+                    tool.result_preview = content.chars().take(200).collect();
+                }
+                // After tool result, Claude may continue streaming text
+                self.status = AppStatus::Streaming;
+            }
+            BridgeEvent::ThinkingStart => {
+                self.ensure_active_turn();
+                if let Some(ConversationItem::AssistantTurn { blocks, .. }) = self.items.last_mut()
+                {
+                    blocks.push(TurnBlock::Thinking {
+                        content: String::new(),
+                        is_streaming: true,
+                    });
+                }
+            }
+            BridgeEvent::ThinkingDelta { text } => {
+                if let Some(thinking) = self.last_thinking_mut() {
+                    thinking.push_str(text);
+                }
+            }
+            BridgeEvent::ThinkingStop => {
+                // Mark thinking as committed
+                if let Some(ConversationItem::AssistantTurn { blocks, .. }) = self.items.last_mut()
+                {
+                    for block in blocks.iter_mut().rev() {
+                        if let TurnBlock::Thinking { is_streaming, .. } = block {
+                            *is_streaming = false;
+                            break;
+                        }
+                    }
+                }
+            }
+            BridgeEvent::MessageStop { .. } | BridgeEvent::Core(ClaudeEvent::Result { .. }) => {
+                self.commit_streaming_text();
+                self.finalize_turn();
+                self.status = AppStatus::Ready;
             }
             BridgeEvent::Core(ClaudeEvent::Assistant { message }) => {
-                self.is_waiting = false;
-                // If we have accumulated streaming text and this is a complete
-                // message, commit it
+                // Handle complete assistant messages (non-streaming mode)
+                if self.status == AppStatus::Connecting || self.status == AppStatus::Ready {
+                    self.status = AppStatus::Streaming;
+                }
+                self.ensure_active_turn();
                 for block in &message.content {
                     match block.block_type.as_str() {
                         "text" => {
                             if let Some(text) = &block.text {
-                                // If streaming text matches, it's already accumulated.
-                                // If not (non-streaming mode), use the block text.
-                                if self.streaming_text.is_empty() {
-                                    self.streaming_text.push_str(text);
-                                }
+                                self.append_streaming_text(text);
                             }
                         }
                         "tool_use" => {
                             if let Some(name) = &block.name {
-                                self.tool_calls.push(ToolCallEntry {
-                                    name: name.clone(),
-                                    status: ToolStatus::Running,
-                                });
+                                let id = block.id.clone().unwrap_or_default();
+                                if let Some(ConversationItem::AssistantTurn { blocks, .. }) =
+                                    self.items.last_mut()
+                                {
+                                    blocks.push(TurnBlock::ToolCall(ToolCallItem {
+                                        id,
+                                        name: name.clone(),
+                                        input_json: String::new(),
+                                        result_preview: String::new(),
+                                        status: ToolStatus::Running,
+                                        started_at: Instant::now(),
+                                        is_expanded: false,
+                                    }));
+                                }
                             }
                         }
                         _ => {}
                     }
                 }
             }
-            BridgeEvent::ToolResult { .. } => {
-                // Mark the last running tool as complete
-                if let Some(last) = self.tool_calls.last_mut() {
-                    if matches!(last.status, ToolStatus::Running) {
-                        last.status = ToolStatus::Complete;
-                    }
-                }
-            }
-            BridgeEvent::Core(ClaudeEvent::Result { .. }) => {
-                // Session ended — commit any remaining streaming text
-                self.commit_streaming_text();
-                self.is_waiting = false;
-            }
             BridgeEvent::RateLimit { status, .. } => {
                 self.status_message = Some(format!("Rate limit: {status}"));
             }
-            BridgeEvent::Core(ClaudeEvent::System { .. }) => {}
+            BridgeEvent::PermissionRequest { tool, description } => {
+                self.status_message = Some(format!("Permission requested: {tool} — {description}"));
+            }
             _ => {}
         }
     }
 
-    /// Commit accumulated streaming text as an assistant message.
-    pub fn commit_streaming_text(&mut self) {
-        if !self.streaming_text.is_empty() {
-            let text = std::mem::take(&mut self.streaming_text);
-            self.messages.push(Message {
-                role: MessageRole::Assistant,
-                text,
+    /// Record a sent user message and transition to Thinking.
+    pub fn record_user_message(&mut self, text: String) {
+        self.commit_streaming_text();
+        self.finalize_turn();
+        self.items.push(ConversationItem::UserMessage { text });
+        self.status = AppStatus::Thinking;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    /// Ensure there's an active assistant turn at the end of items.
+    fn ensure_active_turn(&mut self) -> &mut ConversationItem {
+        if !matches!(
+            self.items.last(),
+            Some(ConversationItem::AssistantTurn {
+                is_active: true,
+                ..
+            })
+        ) {
+            self.items.push(ConversationItem::AssistantTurn {
+                blocks: Vec::new(),
+                is_active: true,
             });
-            self.tool_calls.clear();
+        }
+        self.items.last_mut().expect("just pushed")
+    }
+
+    /// Append text to the current streaming text block, creating one if needed.
+    fn append_streaming_text(&mut self, text: &str) {
+        let turn = self.ensure_active_turn();
+        if let ConversationItem::AssistantTurn { blocks, .. } = turn {
+            // Find last streaming text block or create one
+            let needs_new = blocks.last().is_none_or(|b| {
+                !matches!(
+                    b,
+                    TurnBlock::Text {
+                        is_streaming: true,
+                        ..
+                    }
+                )
+            });
+            if needs_new {
+                blocks.push(TurnBlock::Text {
+                    content: String::new(),
+                    is_streaming: true,
+                });
+            }
+            if let Some(TurnBlock::Text { content, .. }) = blocks.last_mut() {
+                content.push_str(text);
+            }
         }
     }
 
-    /// Record a sent user message.
-    pub fn record_user_message(&mut self, text: String) {
-        // Commit any previous assistant response
-        self.commit_streaming_text();
-        self.messages.push(Message {
-            role: MessageRole::User,
-            text,
-        });
-        self.is_waiting = true;
+    /// Commit any streaming text block (mark as not streaming).
+    fn commit_streaming_text(&mut self) {
+        if let Some(ConversationItem::AssistantTurn { blocks, .. }) = self.items.last_mut() {
+            for block in blocks.iter_mut() {
+                if let TurnBlock::Text {
+                    is_streaming,
+                    content,
+                    ..
+                } = block
+                {
+                    if *is_streaming && !content.is_empty() {
+                        *is_streaming = false;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Mark the current turn as finalized.
+    fn finalize_turn(&mut self) {
+        if let Some(ConversationItem::AssistantTurn {
+            is_active, blocks, ..
+        }) = self.items.last_mut()
+        {
+            // Remove empty text blocks
+            blocks.retain(|b| !matches!(b, TurnBlock::Text { content, .. } if content.is_empty()));
+            *is_active = false;
+        }
+    }
+
+    /// Get mutable reference to the last tool call in the active turn.
+    fn last_tool_mut(&mut self) -> Option<&mut ToolCallItem> {
+        if let Some(ConversationItem::AssistantTurn { blocks, .. }) = self.items.last_mut() {
+            blocks.iter_mut().rev().find_map(|b| {
+                if let TurnBlock::ToolCall(tool) = b {
+                    Some(tool)
+                } else {
+                    None
+                }
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Find a tool call by ID in the active turn.
+    fn find_tool_mut(&mut self, tool_use_id: &str) -> Option<&mut ToolCallItem> {
+        if let Some(ConversationItem::AssistantTurn { blocks, .. }) = self.items.last_mut() {
+            blocks.iter_mut().find_map(|b| {
+                if let TurnBlock::ToolCall(tool) = b {
+                    if tool.id == tool_use_id {
+                        return Some(tool);
+                    }
+                }
+                None
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Get mutable reference to the last thinking block's content.
+    fn last_thinking_mut(&mut self) -> Option<&mut String> {
+        if let Some(ConversationItem::AssistantTurn { blocks, .. }) = self.items.last_mut() {
+            blocks.iter_mut().rev().find_map(|b| {
+                if let TurnBlock::Thinking { content, .. } = b {
+                    Some(content)
+                } else {
+                    None
+                }
+            })
+        } else {
+            None
+        }
     }
 }
+
+// ── Rendering ────────────────────────────────────────────────────────────
 
 /// Render the conversation viewport.
 pub fn render_conversation(frame: &mut Frame, state: &mut AppState, area: Rect) {
     let mut lines: Vec<Line> = Vec::new();
 
-    // Render committed messages
-    for msg in &state.messages {
-        let (prefix, style) = match msg.role {
-            MessageRole::User => (
-                "You: ",
-                Style::default()
+    for item in &state.items {
+        match item {
+            ConversationItem::UserMessage { text } => {
+                let style = Style::default()
                     .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            MessageRole::Assistant => ("", Style::default().fg(Color::White)),
-            MessageRole::System => ("System: ", Style::default().fg(Color::Yellow)),
-        };
-
-        lines.push(Line::from(vec![Span::styled(prefix, style)]));
-        for text_line in msg.text.lines() {
-            lines.push(Line::from(Span::styled(text_line.to_string(), style)));
+                    .add_modifier(Modifier::BOLD);
+                lines.push(Line::from(Span::styled("You: ", style)));
+                for text_line in text.lines() {
+                    lines.push(Line::from(Span::styled(text_line.to_string(), style)));
+                }
+                lines.push(Line::from(""));
+            }
+            ConversationItem::AssistantTurn { blocks, is_active } => {
+                for block in blocks {
+                    match block {
+                        TurnBlock::Text {
+                            content,
+                            is_streaming,
+                        } => {
+                            let style = Style::default().fg(Color::White);
+                            for text_line in content.lines() {
+                                lines.push(Line::from(Span::styled(text_line.to_string(), style)));
+                            }
+                            if *is_streaming {
+                                lines.push(Line::from(Span::styled(
+                                    "▌",
+                                    Style::default().fg(Color::Green),
+                                )));
+                            }
+                        }
+                        TurnBlock::ToolCall(tool) => {
+                            render_tool_call_line(&mut lines, tool, state.frame_count);
+                        }
+                        TurnBlock::Thinking {
+                            content,
+                            is_streaming,
+                        } => {
+                            if state.show_thinking {
+                                let style = Style::default()
+                                    .fg(Color::DarkGray)
+                                    .add_modifier(Modifier::ITALIC);
+                                lines.push(Line::from(Span::styled(
+                                    "┌─ Thinking ─",
+                                    Style::default().fg(Color::DarkGray),
+                                )));
+                                for text_line in content.lines().take(20) {
+                                    lines.push(Line::from(Span::styled(
+                                        format!("│ {text_line}"),
+                                        style,
+                                    )));
+                                }
+                                if content.lines().count() > 20 {
+                                    lines.push(Line::from(Span::styled(
+                                        format!(
+                                            "│ [... {} more lines]",
+                                            content.lines().count() - 20
+                                        ),
+                                        style,
+                                    )));
+                                }
+                                if *is_streaming {
+                                    lines.push(Line::from(Span::styled("│ ▌", style)));
+                                }
+                                lines.push(Line::from(Span::styled(
+                                    "└─────────────",
+                                    Style::default().fg(Color::DarkGray),
+                                )));
+                            } else if !content.is_empty() {
+                                let char_count = if content.len() >= 1000 {
+                                    format!("{:.1}k", content.len() as f64 / 1000.0)
+                                } else {
+                                    format!("{}", content.len())
+                                };
+                                let label = if *is_streaming {
+                                    format!("▸ Thinking ({char_count} chars)...")
+                                } else {
+                                    format!("▸ Thinking ({char_count} chars)")
+                                };
+                                lines.push(Line::from(Span::styled(
+                                    label,
+                                    Style::default().fg(Color::DarkGray),
+                                )));
+                            }
+                        }
+                    }
+                }
+                // Thinking indicator when turn is active but no content yet
+                if *is_active && blocks.is_empty() && state.status == AppStatus::Thinking {
+                    let spinner = state.status.spinner(state.frame_count).unwrap_or("⠋");
+                    lines.push(Line::from(Span::styled(
+                        format!("{spinner} Thinking..."),
+                        Style::default()
+                            .fg(Color::DarkGray)
+                            .add_modifier(Modifier::ITALIC),
+                    )));
+                }
+                if !is_active {
+                    lines.push(Line::from(""));
+                }
+            }
+            ConversationItem::SystemNotice { text } => {
+                lines.push(Line::from(Span::styled(
+                    text.clone(),
+                    Style::default().fg(Color::Yellow),
+                )));
+                lines.push(Line::from(""));
+            }
         }
-        lines.push(Line::from(""));
     }
 
-    // Render active tool calls
-    for tool in &state.tool_calls {
-        let indicator = match tool.status {
-            ToolStatus::Running => "⟳",
-            ToolStatus::Complete => "✓",
-        };
-        lines.push(Line::from(Span::styled(
-            format!("  {indicator} {}", tool.name),
-            Style::default().fg(Color::DarkGray),
-        )));
-    }
-
-    // Render streaming text
-    if !state.streaming_text.is_empty() {
-        for text_line in state.streaming_text.lines() {
-            lines.push(Line::from(Span::styled(
-                text_line.to_string(),
-                Style::default().fg(Color::White),
-            )));
-        }
-        // Streaming cursor
-        lines.push(Line::from(Span::styled(
-            "▌",
-            Style::default().fg(Color::Green),
-        )));
-    }
-
-    // Waiting indicator
-    if state.is_waiting {
-        lines.push(Line::from(Span::styled(
-            "Thinking...",
-            Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::ITALIC),
-        )));
-    }
-
-    let text = Text::from(lines.clone());
+    let text = Text::from(lines);
     let content_height = text.height() as u16;
     state.scroll.set_viewport_height(area.height);
     state.scroll.set_content_height(content_height);
@@ -253,10 +572,90 @@ pub fn render_conversation(frame: &mut Frame, state: &mut AppState, area: Rect) 
     frame.render_widget(paragraph, area);
 }
 
+/// Render a single tool call line in the conversation.
+fn render_tool_call_line(lines: &mut Vec<Line>, tool: &ToolCallItem, frame_count: u64) {
+    let elapsed = tool.started_at.elapsed().as_secs_f64();
+
+    match &tool.status {
+        ToolStatus::InputStreaming => {
+            let spinner = AppStatus::ToolRunning.spinner(frame_count).unwrap_or("⟳");
+            let preview: String = tool.input_json.chars().take(60).collect();
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("  {spinner} {} ", tool.name),
+                    Style::default().fg(Color::Cyan),
+                ),
+                Span::styled(
+                    format!("[{elapsed:.1}s] "),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(format!("{preview}▌"), Style::default().fg(Color::DarkGray)),
+            ]));
+        }
+        ToolStatus::Running => {
+            let spinner = AppStatus::ToolRunning.spinner(frame_count).unwrap_or("⟳");
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("  {spinner} {} ", tool.name),
+                    Style::default().fg(Color::Cyan),
+                ),
+                Span::styled(
+                    format!("[{elapsed:.1}s]"),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]));
+        }
+        ToolStatus::Complete { elapsed_secs } => {
+            let preview: String = if tool.result_preview.is_empty() {
+                "done".to_string()
+            } else {
+                tool.result_preview
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .chars()
+                    .take(60)
+                    .collect()
+            };
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("  ✓ {} ", tool.name),
+                    Style::default().fg(Color::Green),
+                ),
+                Span::styled(
+                    format!("[{elapsed_secs:.1}s] "),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(preview, Style::default().fg(Color::DarkGray)),
+            ]));
+        }
+        ToolStatus::Error { message } => {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("  ✗ {} ", tool.name),
+                    Style::default().fg(Color::Red),
+                ),
+                Span::styled(
+                    format!("[{elapsed:.1}s] "),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(message.clone(), Style::default().fg(Color::Red)),
+            ]));
+        }
+    }
+}
+
 /// Render the input area.
 pub fn render_input(frame: &mut Frame, state: &AppState, area: Rect) {
+    let placeholder = match state.status {
+        AppStatus::Connecting => "Connecting...",
+        AppStatus::Ready => "Type a message...",
+        AppStatus::Thinking | AppStatus::Streaming | AppStatus::ToolRunning => "Waiting...",
+        AppStatus::Error => "Error — press Ctrl+C to exit",
+    };
+
     let display_text = if state.input_buffer.is_empty() {
-        Span::styled("Type a message...", Style::default().fg(Color::DarkGray))
+        Span::styled(placeholder, Style::default().fg(Color::DarkGray))
     } else {
         Span::styled(
             state.input_buffer.as_str(),
@@ -272,10 +671,9 @@ pub fn render_input(frame: &mut Frame, state: &AppState, area: Rect) {
 
     frame.render_widget(input, area);
 
-    // Position cursor after the input text (inside the bordered area)
-    // +1 for top border, +2 for "> " prefix
+    // Cursor
     let cursor_x = area.x + 2 + state.input_buffer.len() as u16;
-    let cursor_y = area.y + 1; // +1 for top border
+    let cursor_y = area.y + 1;
     frame.set_cursor_position((cursor_x.min(area.x + area.width - 1), cursor_y));
 }
 
@@ -287,6 +685,14 @@ pub fn render_status(frame: &mut Frame, state: &AppState, area: Rect) {
         .unwrap_or_else(std::sync::PoisonError::into_inner);
 
     let mut parts: Vec<Span> = Vec::new();
+
+    // Status indicator
+    if let Some(spinner) = state.status.spinner(state.frame_count) {
+        parts.push(Span::styled(
+            format!("{spinner} "),
+            Style::default().fg(Color::Yellow),
+        ));
+    }
 
     // Model
     if !m.model.is_empty() {
@@ -335,6 +741,17 @@ pub fn render_status(frame: &mut Frame, state: &AppState, area: Rect) {
             format!("⟳ {tool}"),
             Style::default().fg(Color::Cyan),
         ));
+    }
+
+    // Thinking chars
+    if m.thinking_chars > 0 {
+        parts.push(Span::raw(" │ "));
+        let label = if m.thinking_chars >= 1000 {
+            format!("think:{:.1}k", m.thinking_chars as f64 / 1000.0)
+        } else {
+            format!("think:{}", m.thinking_chars)
+        };
+        parts.push(Span::styled(label, Style::default().fg(Color::DarkGray)));
     }
 
     // Rate limit

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -243,13 +243,10 @@ pub fn render_conversation(frame: &mut Frame, state: &mut AppState, area: Rect) 
 
     let text = Text::from(lines.clone());
     let content_height = text.height() as u16;
-    state
-        .scroll
-        .set_viewport_height(area.height.saturating_sub(2)); // account for borders
+    state.scroll.set_viewport_height(area.height);
     state.scroll.set_content_height(content_height);
 
     let paragraph = Paragraph::new(text)
-        .block(Block::default().borders(Borders::ALL).title(" aclaude "))
         .wrap(Wrap { trim: false })
         .scroll((state.scroll.offset, 0));
 
@@ -271,7 +268,7 @@ pub fn render_input(frame: &mut Frame, state: &AppState, area: Rect) {
         Span::styled("> ", Style::default().fg(Color::Green)),
         display_text,
     ]))
-    .block(Block::default().borders(Borders::ALL));
+    .block(Block::default().borders(Borders::TOP | Borders::BOTTOM));
 
     frame.render_widget(input, area);
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -5,7 +5,7 @@
 //! viewport, input area, and status bar using a `RenderCtx` for purity.
 
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -219,6 +219,8 @@ pub struct AppState {
     pub permission_mode: PermissionMode,
     /// Pending permission prompt (blocks normal input when Some).
     pub pending_permission: Option<PermissionPrompt>,
+    /// When the status message was set (for auto-clear after timeout).
+    pub status_message_at: Option<Instant>,
 }
 
 impl AppState {
@@ -236,6 +238,7 @@ impl AppState {
             frame_count: 0,
             permission_mode: PermissionMode::Default,
             pending_permission: None,
+            status_message_at: None,
         }
     }
 
@@ -513,6 +516,22 @@ impl AppState {
             })
         } else {
             None
+        }
+    }
+
+    /// Set a status message with auto-clear timestamp.
+    pub fn set_status(&mut self, msg: String) {
+        self.status_message = Some(msg);
+        self.status_message_at = Some(Instant::now());
+    }
+
+    /// Clear expired status messages (older than 5 seconds).
+    pub fn tick_status_timeout(&mut self) {
+        if let Some(at) = self.status_message_at {
+            if at.elapsed() >= Duration::from_secs(5) {
+                self.status_message = None;
+                self.status_message_at = None;
+            }
         }
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -129,6 +129,68 @@ pub enum ToolStatus {
     Error { message: String },
 }
 
+/// Permission mode — cycled via Shift+Tab.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PermissionMode {
+    Default,
+    AcceptEdits,
+    Plan,
+    Auto,
+    Bypass,
+}
+
+impl PermissionMode {
+    /// Cycle to the next permission mode.
+    pub fn next(self) -> Self {
+        match self {
+            Self::Default => Self::AcceptEdits,
+            Self::AcceptEdits => Self::Plan,
+            Self::Plan => Self::Auto,
+            Self::Auto => Self::Bypass,
+            Self::Bypass => Self::Default,
+        }
+    }
+
+    /// Display label for the status bar.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::AcceptEdits => "acceptEdits",
+            Self::Plan => "plan",
+            Self::Auto => "auto",
+            Self::Bypass => "bypass",
+        }
+    }
+
+    /// Color for the status bar indicator.
+    pub fn color(self) -> Color {
+        match self {
+            Self::Default => Color::Green,
+            Self::AcceptEdits | Self::Plan => Color::Yellow,
+            Self::Auto => Color::Cyan,
+            Self::Bypass => Color::Red,
+        }
+    }
+
+    /// Parse from system/init permission_mode value.
+    pub fn parse_mode(s: &str) -> Self {
+        match s {
+            "acceptEdits" => Self::AcceptEdits,
+            "plan" => Self::Plan,
+            "auto" => Self::Auto,
+            "dontAsk" | "bypass" | "bypassPermissions" => Self::Bypass,
+            _ => Self::Default,
+        }
+    }
+}
+
+/// A pending permission prompt for tool approval.
+#[derive(Debug)]
+pub struct PermissionPrompt {
+    pub tool: String,
+    pub description: String,
+}
+
 // ── App State ────────────────────────────────────────────────────────────
 
 /// Application state for the TUI.
@@ -153,6 +215,10 @@ pub struct AppState {
     pub show_thinking: bool,
     /// Frame counter for spinner animation.
     pub frame_count: u64,
+    /// Current permission mode.
+    pub permission_mode: PermissionMode,
+    /// Pending permission prompt (blocks normal input when Some).
+    pub pending_permission: Option<PermissionPrompt>,
 }
 
 impl AppState {
@@ -168,6 +234,8 @@ impl AppState {
             available_slash_commands: Vec::new(),
             show_thinking: false,
             frame_count: 0,
+            permission_mode: PermissionMode::Default,
+            pending_permission: None,
         }
     }
 
@@ -176,10 +244,12 @@ impl AppState {
         match event {
             BridgeEvent::SessionInit {
                 available_slash_commands,
+                permission_mode,
                 ..
             } => {
                 self.status = AppStatus::Ready;
                 self.available_slash_commands = available_slash_commands.clone();
+                self.permission_mode = PermissionMode::parse_mode(permission_mode);
             }
             BridgeEvent::Core(ClaudeEvent::System { .. }) => {
                 // Legacy system event without init subtype
@@ -308,7 +378,10 @@ impl AppState {
                 self.status_message = Some(format!("Rate limit: {status}"));
             }
             BridgeEvent::PermissionRequest { tool, description } => {
-                self.status_message = Some(format!("Permission requested: {tool} — {description}"));
+                self.pending_permission = Some(PermissionPrompt {
+                    tool: tool.clone(),
+                    description: description.clone(),
+                });
             }
             _ => {}
         }
@@ -743,6 +816,13 @@ pub fn render_status(frame: &mut Frame, state: &AppState, area: Rect) {
         ));
     }
 
+    // Permission mode
+    parts.push(Span::raw(" │ "));
+    parts.push(Span::styled(
+        format!("[{}]", state.permission_mode.label()),
+        Style::default().fg(state.permission_mode.color()),
+    ));
+
     // Active tool
     if let Some(tool) = &m.active_tool {
         parts.push(Span::raw(" │ "));
@@ -780,4 +860,49 @@ pub fn render_status(frame: &mut Frame, state: &AppState, area: Rect) {
 
     let status = Paragraph::new(Line::from(parts));
     frame.render_widget(status, area);
+}
+
+/// Render the permission prompt overlay above the input area.
+pub fn render_permission_prompt(frame: &mut Frame, prompt: &PermissionPrompt, area: Rect) {
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("  Tool: ", Style::default().fg(Color::Yellow)),
+            Span::styled(
+                prompt.tool.clone(),
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(Span::styled(
+            format!("  {}", prompt.description),
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "  [a] Allow  ",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "[d] Deny",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+        ]),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Permission Required ")
+        .title_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )
+        .border_style(Style::default().fg(Color::Yellow));
+
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -622,15 +622,17 @@ pub fn render_conversation(frame: &mut Frame, state: &mut AppState, area: Rect) 
                             content,
                             is_streaming,
                         } => {
-                            let style = Style::default().fg(Color::White);
-                            for text_line in content.lines() {
-                                lines.push(Line::from(Span::styled(text_line.to_string(), style)));
-                            }
                             if *is_streaming {
+                                // Streaming text — render with markdown for
+                                // partial formatting (code blocks, headers)
+                                lines.extend(super::markdown::render_markdown_safe(content));
                                 lines.push(Line::from(Span::styled(
                                     "▌",
                                     Style::default().fg(Color::Green),
                                 )));
+                            } else {
+                                // Committed text — full markdown rendering
+                                lines.extend(super::markdown::render_markdown_safe(content));
                             }
                         }
                         TurnBlock::ToolCall(tool) => {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -271,6 +271,12 @@ pub fn render_input(frame: &mut Frame, state: &AppState, area: Rect) {
     .block(Block::default().borders(Borders::TOP | Borders::BOTTOM));
 
     frame.render_widget(input, area);
+
+    // Position cursor after the input text (inside the bordered area)
+    // +1 for top border, +2 for "> " prefix
+    let cursor_x = area.x + 2 + state.input_buffer.len() as u16;
+    let cursor_y = area.y + 1; // +1 for top border
+    frame.set_cursor_position((cursor_x.min(area.x + area.width - 1), cursor_y));
 }
 
 /// Render the status bar.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -216,8 +216,8 @@ pub struct PermissionPrompt {
 pub struct AppState {
     /// Structured conversation history.
     pub items: Vec<ConversationItem>,
-    /// User input buffer.
-    pub input_buffer: String,
+    /// User input state (buffer + cursor).
+    pub input: super::input::InputState,
     /// Portrait size setting.
     pub portrait_size: PortraitSize,
     /// Whether the portrait is visible.
@@ -250,7 +250,7 @@ impl AppState {
     pub fn new(metrics: Arc<Mutex<SessionMetrics>>) -> Self {
         Self {
             items: Vec::new(),
-            input_buffer: String::new(),
+            input: super::input::InputState::default(),
             portrait_size: PortraitSize::Medium,
             portrait_visible: true,
             portrait_position: PortraitPosition::TopRight,
@@ -780,11 +780,11 @@ pub fn render_input(frame: &mut Frame, state: &AppState, area: Rect) {
         AppStatus::Error => "Error — press Ctrl+C to exit",
     };
 
-    let display_text = if state.input_buffer.is_empty() {
+    let display_text = if state.input.buffer.is_empty() {
         Span::styled(placeholder, Style::default().fg(Color::DarkGray))
     } else {
         Span::styled(
-            state.input_buffer.as_str(),
+            state.input.buffer.as_str(),
             Style::default().fg(Color::White),
         )
     };
@@ -797,8 +797,9 @@ pub fn render_input(frame: &mut Frame, state: &AppState, area: Rect) {
 
     frame.render_widget(input, area);
 
-    // Cursor
-    let cursor_x = area.x + 2 + state.input_buffer.len() as u16;
+    // Position cursor at the InputState cursor position
+    // +1 for top border, +2 for "> " prefix
+    let cursor_x = area.x + 2 + state.input.cursor as u16;
     let cursor_y = area.y + 1;
     frame.set_cursor_position((cursor_x.min(area.x + area.width - 1), cursor_y));
 }

--- a/src/tui/diff.rs
+++ b/src/tui/diff.rs
@@ -1,0 +1,346 @@
+//! Tool call rendering with diff display.
+//!
+//! Dispatches rendering by tool name: Edit shows unified diffs, Read shows
+//! file content preview, Bash shows command and output, Write shows path.
+//! Uses `similar` for text diffing.
+
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use similar::{ChangeTag, TextDiff};
+
+use super::app::ToolCallItem;
+
+/// Maximum lines of tool output to show when collapsed.
+const MAX_PREVIEW_LINES: usize = 12;
+
+/// Context lines around diff changes.
+const DIFF_CONTEXT: usize = 3;
+
+/// Render a completed tool call into displayable lines.
+///
+/// Dispatches by tool name for specialized rendering. Returns lines
+/// suitable for embedding in the conversation viewport.
+pub fn render_tool_call(item: &ToolCallItem) -> Vec<Line<'static>> {
+    let input: serde_json::Value =
+        serde_json::from_str(&item.input_json).unwrap_or(serde_json::Value::Null);
+
+    match item.name.as_str() {
+        "Edit" => render_edit(&input),
+        "Read" => render_read(&input, &item.result_preview, item.is_expanded),
+        "Write" => render_write(&input),
+        "Bash" => render_bash(&input, &item.result_preview, item.is_expanded),
+        "Grep" => render_grep(&input, &item.result_preview, item.is_expanded),
+        "Glob" => render_glob(&input, &item.result_preview, item.is_expanded),
+        _ => render_generic(&item.name, &input),
+    }
+}
+
+/// Render a tool result (output) into displayable lines.
+pub fn render_result_preview(result: &str, expanded: bool) -> Vec<Line<'static>> {
+    let max = if expanded {
+        usize::MAX
+    } else {
+        MAX_PREVIEW_LINES
+    };
+    let total = result.lines().count();
+    let mut lines: Vec<Line<'static>> = result
+        .lines()
+        .take(max)
+        .map(|l| {
+            Line::from(Span::styled(
+                format!("    {l}"),
+                Style::default().fg(Color::DarkGray),
+            ))
+        })
+        .collect();
+
+    if !expanded && total > max {
+        lines.push(Line::from(Span::styled(
+            format!("    [... {} more lines]", total - max),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::ITALIC),
+        )));
+    }
+    lines
+}
+
+// ── Tool-specific renderers ──────────────────────────────────────────────
+
+fn render_edit(input: &serde_json::Value) -> Vec<Line<'static>> {
+    let file_path = input
+        .get("file_path")
+        .and_then(|v| v.as_str())
+        .unwrap_or("<unknown>");
+    let old_string = input
+        .get("old_string")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let new_string = input
+        .get("new_string")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let mut lines = vec![Line::from(vec![
+        Span::styled("    ~ ", Style::default().fg(Color::Yellow)),
+        Span::styled(
+            file_path.to_string(),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ])];
+
+    if old_string.is_empty() && new_string.is_empty() {
+        return lines;
+    }
+
+    lines.extend(render_unified_diff(old_string, new_string));
+    lines
+}
+
+fn render_read(input: &serde_json::Value, result: &str, expanded: bool) -> Vec<Line<'static>> {
+    let file_path = input
+        .get("file_path")
+        .and_then(|v| v.as_str())
+        .unwrap_or("<unknown>");
+
+    let mut lines = vec![Line::from(vec![
+        Span::styled("      ", Style::default()),
+        Span::styled(file_path.to_string(), Style::default().fg(Color::White)),
+    ])];
+
+    if !result.is_empty() {
+        lines.extend(render_result_preview(result, expanded));
+    }
+    lines
+}
+
+fn render_write(input: &serde_json::Value) -> Vec<Line<'static>> {
+    let file_path = input
+        .get("file_path")
+        .and_then(|v| v.as_str())
+        .unwrap_or("<unknown>");
+
+    vec![Line::from(vec![
+        Span::styled("    + ", Style::default().fg(Color::Green)),
+        Span::styled(
+            file_path.to_string(),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ])]
+}
+
+fn render_bash(input: &serde_json::Value, result: &str, expanded: bool) -> Vec<Line<'static>> {
+    let command = input
+        .get("command")
+        .and_then(|v| v.as_str())
+        .unwrap_or("<unknown>");
+
+    // Truncate long commands to first line
+    let cmd_display: String = command
+        .lines()
+        .next()
+        .unwrap_or(command)
+        .chars()
+        .take(80)
+        .collect();
+    let truncated = command.lines().count() > 1 || command.len() > 80;
+
+    let mut lines = vec![Line::from(vec![
+        Span::styled("    $ ", Style::default().fg(Color::Magenta)),
+        Span::styled(
+            if truncated {
+                format!("{cmd_display}...")
+            } else {
+                cmd_display
+            },
+            Style::default().fg(Color::Magenta),
+        ),
+    ])];
+
+    if !result.is_empty() {
+        lines.extend(render_result_preview(result, expanded));
+    }
+    lines
+}
+
+fn render_grep(input: &serde_json::Value, result: &str, expanded: bool) -> Vec<Line<'static>> {
+    let pattern = input.get("pattern").and_then(|v| v.as_str()).unwrap_or("");
+    let path = input.get("path").and_then(|v| v.as_str()).unwrap_or(".");
+
+    let mut lines = vec![Line::from(vec![
+        Span::styled("    🔍 ", Style::default()),
+        Span::styled(
+            format!("/{pattern}/ in {path}"),
+            Style::default().fg(Color::Cyan),
+        ),
+    ])];
+
+    if !result.is_empty() {
+        lines.extend(render_result_preview(result, expanded));
+    }
+    lines
+}
+
+fn render_glob(input: &serde_json::Value, result: &str, expanded: bool) -> Vec<Line<'static>> {
+    let pattern = input.get("pattern").and_then(|v| v.as_str()).unwrap_or("");
+
+    let mut lines = vec![Line::from(vec![
+        Span::styled("    📁 ", Style::default()),
+        Span::styled(pattern.to_string(), Style::default().fg(Color::Cyan)),
+    ])];
+
+    if !result.is_empty() {
+        lines.extend(render_result_preview(result, expanded));
+    }
+    lines
+}
+
+fn render_generic(name: &str, input: &serde_json::Value) -> Vec<Line<'static>> {
+    let preview: String = serde_json::to_string(input)
+        .unwrap_or_default()
+        .chars()
+        .take(120)
+        .collect();
+
+    vec![Line::from(vec![
+        Span::styled(
+            format!("    {name}: "),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(preview, Style::default().fg(Color::DarkGray)),
+    ])]
+}
+
+// ── Diff rendering ───────────────────────────────────────────────────────
+
+/// Render a unified diff of old_string vs new_string.
+fn render_unified_diff(old: &str, new: &str) -> Vec<Line<'static>> {
+    let diff = TextDiff::from_lines(old, new);
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut has_changes = false;
+
+    for group in diff.grouped_ops(DIFF_CONTEXT) {
+        for op in &group {
+            for change in diff.iter_changes(op) {
+                has_changes = true;
+                let text = change.value().trim_end_matches('\n').to_string();
+                let (prefix, style) = match change.tag() {
+                    ChangeTag::Delete => ("-", Style::default().fg(Color::Red)),
+                    ChangeTag::Insert => ("+", Style::default().fg(Color::Green)),
+                    ChangeTag::Equal => (" ", Style::default().fg(Color::DarkGray)),
+                };
+                lines.push(Line::from(Span::styled(
+                    format!("      {prefix} {text}"),
+                    style,
+                )));
+            }
+        }
+
+        // Separator between groups
+        if lines.len() < 200 {
+            lines.push(Line::from(Span::styled(
+                "      ───",
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+    }
+
+    // Remove trailing separator
+    if lines
+        .last()
+        .is_some_and(|l| l.spans.first().is_some_and(|s| s.content.contains("───")))
+    {
+        lines.pop();
+    }
+
+    if !has_changes {
+        lines.push(Line::from(Span::styled(
+            "      (no changes)",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unified_diff_shows_changes() {
+        let old = "line1\nline2\nline3\n";
+        let new = "line1\nmodified\nline3\n";
+        let lines = render_unified_diff(old, new);
+
+        let text: Vec<String> = lines.iter().map(ToString::to_string).collect();
+        assert!(text.iter().any(|l| l.contains("- line2")));
+        assert!(text.iter().any(|l| l.contains("+ modified")));
+    }
+
+    #[test]
+    fn unified_diff_empty_inputs() {
+        let lines = render_unified_diff("", "");
+        assert_eq!(lines.len(), 1); // "(no changes)"
+    }
+
+    #[test]
+    fn render_edit_parses_input() {
+        let input: serde_json::Value = serde_json::json!({
+            "file_path": "src/main.rs",
+            "old_string": "fn old() {}",
+            "new_string": "fn new() {}"
+        });
+        let lines = render_edit(&input);
+        let text: Vec<String> = lines.iter().map(ToString::to_string).collect();
+        assert!(text[0].contains("src/main.rs"));
+        assert!(text.iter().any(|l| l.contains("- fn old")));
+        assert!(text.iter().any(|l| l.contains("+ fn new")));
+    }
+
+    #[test]
+    fn render_bash_truncates_long_commands() {
+        let long_cmd = "a".repeat(200);
+        let input = serde_json::json!({ "command": long_cmd });
+        let lines = render_bash(&input, "", false);
+        let text = lines[0].to_string();
+        assert!(text.contains("..."));
+        assert!(text.len() < 200);
+    }
+
+    #[test]
+    fn render_result_preview_truncates() {
+        let result: String = (0..50)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let lines = render_result_preview(&result, false);
+        // 12 lines + 1 "[... N more lines]"
+        assert_eq!(lines.len(), MAX_PREVIEW_LINES + 1);
+        let last = lines.last().unwrap().to_string();
+        assert!(last.contains("more lines"));
+    }
+
+    #[test]
+    fn render_result_preview_expanded_shows_all() {
+        let result: String = (0..50)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let lines = render_result_preview(&result, true);
+        assert_eq!(lines.len(), 50);
+    }
+
+    #[test]
+    fn render_generic_shows_truncated_json() {
+        let input = serde_json::json!({ "key": "value" });
+        let lines = render_generic("CustomTool", &input);
+        assert_eq!(lines.len(), 1);
+        let text = lines[0].to_string();
+        assert!(text.contains("CustomTool"));
+    }
+}

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -1,0 +1,127 @@
+//! Key handling and slash command parsing for the TUI.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// Action resulting from a key press.
+#[derive(Debug)]
+pub enum InputAction {
+    /// Send the input buffer as a user message.
+    SendMessage(String),
+    /// Process a local slash command.
+    SlashCommand(SlashCmd),
+    /// Quit the TUI.
+    Quit,
+    /// Scroll conversation up one line.
+    ScrollUp,
+    /// Scroll conversation down one line.
+    ScrollDown,
+    /// Scroll conversation up one page.
+    PageUp,
+    /// Scroll conversation down one page.
+    PageDown,
+    /// Scroll to bottom of conversation.
+    ScrollEnd,
+    /// No action (key consumed but no effect).
+    None,
+}
+
+/// Parsed slash commands.
+#[derive(Debug)]
+pub enum SlashCmd {
+    /// Set portrait size: /persona portrait size [small|medium|large|original]
+    PortraitSize(String),
+    /// Unknown slash command.
+    Unknown(String),
+}
+
+/// Handle a key event against the current input buffer.
+///
+/// Modifies `input_buffer` in place (for character input, backspace).
+/// Returns an `InputAction` describing what the TUI should do.
+pub fn handle_key(event: KeyEvent, input_buffer: &mut String) -> InputAction {
+    match (event.modifiers, event.code) {
+        // Quit
+        (KeyModifiers::CONTROL, KeyCode::Char('c')) => InputAction::Quit,
+
+        // Submit
+        (_, KeyCode::Enter) => {
+            let text = input_buffer.trim().to_string();
+            input_buffer.clear();
+            if text.is_empty() {
+                return InputAction::None;
+            }
+            if let Some(cmd) = parse_slash_command(&text) {
+                InputAction::SlashCommand(cmd)
+            } else {
+                InputAction::SendMessage(text)
+            }
+        }
+
+        // Editing
+        (_, KeyCode::Backspace) => {
+            input_buffer.pop();
+            InputAction::None
+        }
+
+        // Scrolling
+        (_, KeyCode::Up) => InputAction::ScrollUp,
+        (_, KeyCode::Down) => InputAction::ScrollDown,
+        (_, KeyCode::PageUp) => InputAction::PageUp,
+        (_, KeyCode::PageDown) => InputAction::PageDown,
+        (_, KeyCode::End) => InputAction::ScrollEnd,
+        (_, KeyCode::Home) => InputAction::ScrollEnd,
+
+        // Character input
+        (_, KeyCode::Char(c)) => {
+            input_buffer.push(c);
+            InputAction::None
+        }
+
+        _ => InputAction::None,
+    }
+}
+
+/// Parse a slash command from input text.
+fn parse_slash_command(text: &str) -> Option<SlashCmd> {
+    if !text.starts_with('/') {
+        return None;
+    }
+
+    let parts: Vec<&str> = text.split_whitespace().collect();
+
+    // /persona portrait size <size>
+    if parts.len() == 4 && parts[0] == "/persona" && parts[1] == "portrait" && parts[2] == "size" {
+        let size = parts[3].to_lowercase();
+        if ["small", "medium", "large", "original"].contains(&size.as_str()) {
+            return Some(SlashCmd::PortraitSize(size));
+        }
+    }
+
+    Some(SlashCmd::Unknown(text.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_portrait_size_command() {
+        match parse_slash_command("/persona portrait size large") {
+            Some(SlashCmd::PortraitSize(s)) => assert_eq!(s, "large"),
+            other => panic!("expected PortraitSize, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_unknown_slash_command() {
+        match parse_slash_command("/unknown") {
+            Some(SlashCmd::Unknown(s)) => assert_eq!(s, "/unknown"),
+            other => panic!("expected Unknown, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_slash_returns_none() {
+        assert!(parse_slash_command("hello").is_none());
+    }
+}

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -27,6 +27,8 @@ pub enum InputAction {
     PageDown,
     /// Scroll to bottom of conversation.
     ScrollEnd,
+    /// Toggle expanded output for most recent completed tool call.
+    ToggleExpand,
     /// No action (key consumed but no effect).
     None,
 }
@@ -202,6 +204,9 @@ pub fn handle_key(
     match (event.modifiers, event.code) {
         // Quit
         (KeyModifiers::CONTROL, KeyCode::Char('c')) => InputAction::Quit,
+
+        // Toggle expand tool output
+        (KeyModifiers::CONTROL, KeyCode::Char('o')) => InputAction::ToggleExpand,
 
         // Tab completion
         (_, KeyCode::Tab) => {

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -15,6 +15,10 @@ const LOCAL_COMMANDS: &[&str] = &[
     "/persona portrait size medium",
     "/persona portrait size large",
     "/persona portrait size original",
+    "/persona portrait on",
+    "/persona portrait off",
+    "/persona portrait top",
+    "/persona portrait bottom",
 ];
 
 /// Action resulting from a key press.
@@ -59,6 +63,10 @@ pub enum SlashCmd {
     Cost,
     /// Set portrait size.
     PortraitSize(String),
+    /// Toggle portrait on/off.
+    PortraitToggle(bool),
+    /// Move portrait position (top/bottom).
+    PortraitMove(String),
     /// Forward to Claude Code as a user message (handles /compact, /model, etc.).
     ForwardToAgent(String),
     /// Unknown slash command.
@@ -360,11 +368,20 @@ fn parse_slash_command(text: &str) -> Option<SlashCmd> {
         _ => {}
     }
 
-    // /persona portrait size <size>
-    if parts.len() == 4 && cmd == "/persona" && parts[1] == "portrait" && parts[2] == "size" {
-        let size = parts[3].to_lowercase();
-        if ["small", "medium", "large", "original"].contains(&size.as_str()) {
-            return Some(SlashCmd::PortraitSize(size));
+    // /persona portrait <subcommand>
+    if parts.len() >= 3 && cmd == "/persona" && parts[1] == "portrait" {
+        match parts[2] {
+            "on" => return Some(SlashCmd::PortraitToggle(true)),
+            "off" => return Some(SlashCmd::PortraitToggle(false)),
+            "top" => return Some(SlashCmd::PortraitMove("top".to_string())),
+            "bottom" => return Some(SlashCmd::PortraitMove("bottom".to_string())),
+            "size" if parts.len() == 4 => {
+                let size = parts[3].to_lowercase();
+                if ["small", "medium", "large", "original"].contains(&size.as_str()) {
+                    return Some(SlashCmd::PortraitSize(size));
+                }
+            }
+            _ => {}
         }
     }
 
@@ -469,7 +486,8 @@ mod tests {
     fn tab_complete_partial_prefix() {
         let mut buf = "/per".to_string();
         assert!(tab_complete(&mut buf, &[]));
-        assert_eq!(buf, "/persona portrait size ");
+        // Matches all /persona portrait variants (size, on, off, top, bottom)
+        assert_eq!(buf, "/persona portrait ");
     }
 
     #[test]

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -29,6 +29,12 @@ pub enum InputAction {
     ScrollEnd,
     /// Toggle expanded output for most recent completed tool call.
     ToggleExpand,
+    /// Cycle permission mode (Shift+Tab).
+    CyclePermissionMode,
+    /// Allow pending permission request.
+    PermissionAllow,
+    /// Deny pending permission request.
+    PermissionDeny,
     /// No action (key consumed but no effect).
     None,
 }
@@ -194,19 +200,27 @@ fn longest_common_prefix(strings: &[&str]) -> String {
 
 /// Handle a key event against the current input buffer and history.
 ///
-/// Modifies `input_buffer` in place (for character input, backspace, history, tab).
-/// Returns an `InputAction` describing what the TUI should do.
+/// When `has_permission_prompt` is true, `a` and `d` keys are intercepted
+/// for permission allow/deny before normal character input.
 pub fn handle_key(
     event: KeyEvent,
     input_buffer: &mut String,
     history: &mut InputHistory,
+    has_permission_prompt: bool,
 ) -> InputAction {
     match (event.modifiers, event.code) {
-        // Quit
+        // Quit (always available)
         (KeyModifiers::CONTROL, KeyCode::Char('c')) => InputAction::Quit,
 
         // Toggle expand tool output
         (KeyModifiers::CONTROL, KeyCode::Char('o')) => InputAction::ToggleExpand,
+
+        // Cycle permission mode (Shift+Tab)
+        (KeyModifiers::SHIFT, KeyCode::BackTab) => InputAction::CyclePermissionMode,
+
+        // Permission prompt keys (when active, intercept before normal input)
+        (_, KeyCode::Char('a')) if has_permission_prompt => InputAction::PermissionAllow,
+        (_, KeyCode::Char('d')) if has_permission_prompt => InputAction::PermissionDeny,
 
         // Tab completion
         (_, KeyCode::Tab) => {

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -156,6 +156,12 @@ pub enum InputAction {
     ToggleThinking,
     /// Open external editor for input (Ctrl+G).
     OpenEditor,
+    /// Toggle portrait position top/bottom (Ctrl+P).
+    PortraitTogglePosition,
+    /// Toggle portrait on/off (Alt+P).
+    PortraitToggleVisible,
+    /// Cycle portrait size (Alt+S).
+    PortraitCycleSize,
     /// No action (key consumed but no effect).
     None,
 }
@@ -399,6 +405,11 @@ pub fn handle_key(
             InputAction::None
         }
         (KeyModifiers::CONTROL, KeyCode::Char('g')) => InputAction::OpenEditor,
+
+        // Portrait hotkeys
+        (KeyModifiers::CONTROL, KeyCode::Char('p')) => InputAction::PortraitTogglePosition,
+        (KeyModifiers::ALT, KeyCode::Char('p')) => InputAction::PortraitToggleVisible,
+        (KeyModifiers::ALT, KeyCode::Char('s')) => InputAction::PortraitCycleSize,
 
         // Alt shortcuts
         (KeyModifiers::ALT, KeyCode::Char('t')) => InputAction::ToggleThinking,

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -1,10 +1,15 @@
 //! Key handling, slash command parsing, tab completion, and input history.
 
+use std::path::Path;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-/// Known slash commands for tab completion.
-const KNOWN_COMMANDS: &[&str] = &[
+/// Static slash commands (always available, handled locally by aclaude).
+const LOCAL_COMMANDS: &[&str] = &[
+    "/clear",
+    "/cost",
     "/exit",
+    "/help",
     "/login",
     "/persona portrait size small",
     "/persona portrait size medium",
@@ -46,23 +51,25 @@ pub enum SlashCmd {
     Exit,
     /// Show auth/login info.
     Login,
-    /// Set portrait size: /persona portrait size [small|medium|large|original]
+    /// Clear conversation display.
+    Clear,
+    /// Show available commands and keybindings.
+    Help,
+    /// Show session cost from metrics.
+    Cost,
+    /// Set portrait size.
     PortraitSize(String),
+    /// Forward to Claude Code as a user message (handles /compact, /model, etc.).
+    ForwardToAgent(String),
     /// Unknown slash command.
     Unknown(String),
 }
 
 /// Input history with up/down arrow cycling.
-///
-/// Stores previous inputs and allows browsing through them.
-/// When browsing starts, the current draft is saved and restored
-/// when the user cycles past the newest entry.
 #[derive(Default)]
 pub struct InputHistory {
     entries: Vec<String>,
-    /// Current position in history. `None` means not browsing.
     position: Option<usize>,
-    /// Saved draft from when browsing started.
     draft: String,
 }
 
@@ -71,9 +78,7 @@ impl InputHistory {
         Self::default()
     }
 
-    /// Record a submitted input.
     pub fn push(&mut self, entry: String) {
-        // Don't store empty or duplicate-of-last entries
         if entry.is_empty() || self.entries.last().is_some_and(|last| last == &entry) {
             self.position = None;
             return;
@@ -82,23 +87,18 @@ impl InputHistory {
         self.position = None;
     }
 
-    /// Navigate to an older entry (up arrow). Returns the text to display.
     pub fn prev(&mut self, current_input: &str) -> Option<&str> {
         if self.entries.is_empty() {
             return None;
         }
         match self.position {
             None => {
-                // Start browsing — save current input as draft
                 self.draft = current_input.to_string();
                 let idx = self.entries.len() - 1;
                 self.position = Some(idx);
                 Some(&self.entries[idx])
             }
-            Some(0) => {
-                // Already at oldest — stay put
-                Some(&self.entries[0])
-            }
+            Some(0) => Some(&self.entries[0]),
             Some(idx) => {
                 let new_idx = idx - 1;
                 self.position = Some(new_idx);
@@ -107,14 +107,11 @@ impl InputHistory {
         }
     }
 
-    /// Navigate to a newer entry (down arrow). Returns the text to display,
-    /// or `None` if we've cycled past the newest entry (restores draft).
     pub fn newer(&mut self) -> NextResult<'_> {
         match self.position {
             None => NextResult::NotBrowsing,
             Some(idx) => {
                 if idx + 1 >= self.entries.len() {
-                    // Past newest — restore draft
                     self.position = None;
                     NextResult::Draft(&self.draft)
                 } else {
@@ -127,31 +124,44 @@ impl InputHistory {
     }
 }
 
-/// Result of navigating forward in history.
 pub enum NextResult<'a> {
-    /// An older entry.
     Entry(&'a str),
-    /// Restored draft (cycled past newest).
     Draft(&'a str),
-    /// Not currently browsing history.
     NotBrowsing,
 }
 
-/// Tab-complete a slash command.
+/// Tab-complete slash commands or @ file paths.
 ///
-/// If the input starts with `/`, finds matching commands from the known list.
-/// - Single match: completes to that command.
-/// - Multiple matches: completes to longest common prefix.
-/// - No match: no change.
-///
-/// Returns true if the buffer was modified.
-pub fn tab_complete(input_buffer: &mut String) -> bool {
+/// For slash commands: merges static local commands with dynamic commands
+/// from system/init. For @ file paths: completes from the current directory.
+pub fn tab_complete(input_buffer: &mut String, dynamic_commands: &[String]) -> bool {
+    // @ file path completion
+    if let Some(at_pos) = input_buffer.rfind('@') {
+        let partial = &input_buffer[at_pos + 1..];
+        if let Some(completed) = complete_file_path(partial) {
+            let prefix = input_buffer[..at_pos + 1].to_string();
+            *input_buffer = format!("{prefix}{completed}");
+            return true;
+        }
+        return false;
+    }
+
+    // Slash command completion
     if !input_buffer.starts_with('/') {
         return false;
     }
 
     let prefix = input_buffer.as_str();
-    let matches: Vec<&str> = KNOWN_COMMANDS
+
+    // Build combined command list: local + dynamic
+    let mut all_commands: Vec<&str> = LOCAL_COMMANDS.to_vec();
+    for cmd in dynamic_commands {
+        if !all_commands.contains(&cmd.as_str()) {
+            all_commands.push(cmd);
+        }
+    }
+
+    let matches: Vec<&str> = all_commands
         .iter()
         .filter(|cmd| cmd.starts_with(prefix) && **cmd != prefix)
         .copied()
@@ -164,7 +174,6 @@ pub fn tab_complete(input_buffer: &mut String) -> bool {
             true
         }
         _ => {
-            // Complete to longest common prefix
             let lcp = longest_common_prefix(&matches);
             if lcp.len() > input_buffer.len() {
                 *input_buffer = lcp;
@@ -176,7 +185,61 @@ pub fn tab_complete(input_buffer: &mut String) -> bool {
     }
 }
 
-/// Find the longest common prefix of a set of strings.
+/// Complete a file path from the current directory.
+fn complete_file_path(partial: &str) -> Option<String> {
+    if partial.is_empty() {
+        return None;
+    }
+
+    let (dir, file_prefix) = if let Some(sep) = partial.rfind('/') {
+        (&partial[..=sep], &partial[sep + 1..])
+    } else {
+        (".", partial)
+    };
+
+    let dir_path = Path::new(dir);
+    let entries = std::fs::read_dir(dir_path).ok()?;
+
+    let mut matches: Vec<String> = entries
+        .filter_map(std::result::Result::ok)
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with(file_prefix) {
+                let full = if dir == "." {
+                    name
+                } else {
+                    format!("{dir}{name}")
+                };
+                // Append / for directories
+                if entry.file_type().ok()?.is_dir() {
+                    Some(format!("{full}/"))
+                } else {
+                    Some(full)
+                }
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    matches.sort();
+
+    match matches.len() {
+        0 => None,
+        1 => Some(matches.into_iter().next().expect("checked len")),
+        _ => {
+            // Complete to longest common prefix
+            let refs: Vec<&str> = matches.iter().map(String::as_str).collect();
+            let lcp = longest_common_prefix(&refs);
+            if lcp.len() > partial.len() {
+                Some(lcp)
+            } else {
+                None
+            }
+        }
+    }
+}
+
 fn longest_common_prefix(strings: &[&str]) -> String {
     if strings.is_empty() {
         return String::new();
@@ -199,14 +262,12 @@ fn longest_common_prefix(strings: &[&str]) -> String {
 }
 
 /// Handle a key event against the current input buffer and history.
-///
-/// When `has_permission_prompt` is true, `a` and `d` keys are intercepted
-/// for permission allow/deny before normal character input.
 pub fn handle_key(
     event: KeyEvent,
     input_buffer: &mut String,
     history: &mut InputHistory,
     has_permission_prompt: bool,
+    dynamic_commands: &[String],
 ) -> InputAction {
     match (event.modifiers, event.code) {
         // Quit (always available)
@@ -222,9 +283,9 @@ pub fn handle_key(
         (_, KeyCode::Char('a')) if has_permission_prompt => InputAction::PermissionAllow,
         (_, KeyCode::Char('d')) if has_permission_prompt => InputAction::PermissionDeny,
 
-        // Tab completion
+        // Tab completion (slash commands + @ file paths)
         (_, KeyCode::Tab) => {
-            tab_complete(input_buffer);
+            tab_complete(input_buffer, dynamic_commands);
             InputAction::None
         }
 
@@ -265,7 +326,7 @@ pub fn handle_key(
             InputAction::None
         }
 
-        // Scrolling (page-level only — up/down are for history)
+        // Scrolling
         (_, KeyCode::PageUp) => InputAction::PageUp,
         (_, KeyCode::PageDown) => InputAction::PageDown,
         (_, KeyCode::End) => InputAction::ScrollEnd,
@@ -288,21 +349,43 @@ fn parse_slash_command(text: &str) -> Option<SlashCmd> {
     }
 
     let parts: Vec<&str> = text.split_whitespace().collect();
+    let cmd = parts.first().copied().unwrap_or("");
 
-    match parts.first().copied() {
-        Some("/exit") => return Some(SlashCmd::Exit),
-        Some("/login") => return Some(SlashCmd::Login),
+    match cmd {
+        "/exit" | "/quit" => return Some(SlashCmd::Exit),
+        "/login" => return Some(SlashCmd::Login),
+        "/clear" => return Some(SlashCmd::Clear),
+        "/help" => return Some(SlashCmd::Help),
+        "/cost" => return Some(SlashCmd::Cost),
         _ => {}
     }
 
     // /persona portrait size <size>
-    if parts.len() == 4 && parts[0] == "/persona" && parts[1] == "portrait" && parts[2] == "size" {
+    if parts.len() == 4 && cmd == "/persona" && parts[1] == "portrait" && parts[2] == "size" {
         let size = parts[3].to_lowercase();
         if ["small", "medium", "large", "original"].contains(&size.as_str()) {
             return Some(SlashCmd::PortraitSize(size));
         }
     }
 
+    // Known Claude Code commands — forward as user messages
+    const FORWARD_COMMANDS: &[&str] = &[
+        "/compact",
+        "/model",
+        "/init",
+        "/review",
+        "/bug",
+        "/stats",
+        "/doctor",
+        "/config",
+        "/permissions",
+    ];
+    if FORWARD_COMMANDS.contains(&cmd) {
+        return Some(SlashCmd::ForwardToAgent(text.to_string()));
+    }
+
+    // Any other / command from system/init available_slash_commands
+    // is also forwarded (MCP, skills, etc.)
     Some(SlashCmd::Unknown(text.to_string()))
 }
 
@@ -316,8 +399,36 @@ mod tests {
     }
 
     #[test]
+    fn parse_quit_alias() {
+        assert_eq!(parse_slash_command("/quit"), Some(SlashCmd::Exit));
+    }
+
+    #[test]
     fn parse_login() {
         assert_eq!(parse_slash_command("/login"), Some(SlashCmd::Login));
+    }
+
+    #[test]
+    fn parse_clear() {
+        assert_eq!(parse_slash_command("/clear"), Some(SlashCmd::Clear));
+    }
+
+    #[test]
+    fn parse_help() {
+        assert_eq!(parse_slash_command("/help"), Some(SlashCmd::Help));
+    }
+
+    #[test]
+    fn parse_cost() {
+        assert_eq!(parse_slash_command("/cost"), Some(SlashCmd::Cost));
+    }
+
+    #[test]
+    fn parse_forward_compact() {
+        assert_eq!(
+            parse_slash_command("/compact"),
+            Some(SlashCmd::ForwardToAgent("/compact".to_string()))
+        );
     }
 
     #[test]
@@ -344,48 +455,55 @@ mod tests {
     #[test]
     fn tab_complete_single_match() {
         let mut buf = "/ex".to_string();
-        assert!(tab_complete(&mut buf));
+        assert!(tab_complete(&mut buf, &[]));
         assert_eq!(buf, "/exit");
     }
 
     #[test]
     fn tab_complete_common_prefix() {
         let mut buf = "/persona portrait size ".to_string();
-        // All four size variants match — no common prefix beyond input
-        assert!(!tab_complete(&mut buf));
+        assert!(!tab_complete(&mut buf, &[]));
     }
 
     #[test]
     fn tab_complete_partial_prefix() {
         let mut buf = "/per".to_string();
-        assert!(tab_complete(&mut buf));
+        assert!(tab_complete(&mut buf, &[]));
         assert_eq!(buf, "/persona portrait size ");
     }
 
     #[test]
     fn tab_complete_no_match() {
         let mut buf = "/xyz".to_string();
-        assert!(!tab_complete(&mut buf));
+        assert!(!tab_complete(&mut buf, &[]));
         assert_eq!(buf, "/xyz");
     }
 
     #[test]
     fn tab_complete_non_slash_ignored() {
         let mut buf = "hello".to_string();
-        assert!(!tab_complete(&mut buf));
+        assert!(!tab_complete(&mut buf, &[]));
         assert_eq!(buf, "hello");
     }
 
     #[test]
     fn tab_complete_exact_match_no_change() {
         let mut buf = "/exit".to_string();
-        assert!(!tab_complete(&mut buf));
+        assert!(!tab_complete(&mut buf, &[]));
+    }
+
+    #[test]
+    fn tab_complete_with_dynamic_commands() {
+        let dynamic = vec!["/my-custom-cmd".to_string()];
+        let mut buf = "/my".to_string();
+        assert!(tab_complete(&mut buf, &dynamic));
+        assert_eq!(buf, "/my-custom-cmd");
     }
 
     #[test]
     fn tab_complete_login() {
         let mut buf = "/lo".to_string();
-        assert!(tab_complete(&mut buf));
+        assert!(tab_complete(&mut buf, &[]));
         assert_eq!(buf, "/login");
     }
 

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -1,6 +1,16 @@
-//! Key handling, slash command parsing, and input history for the TUI.
+//! Key handling, slash command parsing, tab completion, and input history.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// Known slash commands for tab completion.
+const KNOWN_COMMANDS: &[&str] = &[
+    "/exit",
+    "/login",
+    "/persona portrait size small",
+    "/persona portrait size medium",
+    "/persona portrait size large",
+    "/persona portrait size original",
+];
 
 /// Action resulting from a key press.
 #[derive(Debug)]
@@ -22,8 +32,12 @@ pub enum InputAction {
 }
 
 /// Parsed slash commands.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum SlashCmd {
+    /// Exit the TUI.
+    Exit,
+    /// Show auth/login info.
+    Login,
     /// Set portrait size: /persona portrait size [small|medium|large|original]
     PortraitSize(String),
     /// Unknown slash command.
@@ -115,9 +129,70 @@ pub enum NextResult<'a> {
     NotBrowsing,
 }
 
+/// Tab-complete a slash command.
+///
+/// If the input starts with `/`, finds matching commands from the known list.
+/// - Single match: completes to that command.
+/// - Multiple matches: completes to longest common prefix.
+/// - No match: no change.
+///
+/// Returns true if the buffer was modified.
+pub fn tab_complete(input_buffer: &mut String) -> bool {
+    if !input_buffer.starts_with('/') {
+        return false;
+    }
+
+    let prefix = input_buffer.as_str();
+    let matches: Vec<&str> = KNOWN_COMMANDS
+        .iter()
+        .filter(|cmd| cmd.starts_with(prefix) && **cmd != prefix)
+        .copied()
+        .collect();
+
+    match matches.len() {
+        0 => false,
+        1 => {
+            *input_buffer = matches[0].to_string();
+            true
+        }
+        _ => {
+            // Complete to longest common prefix
+            let lcp = longest_common_prefix(&matches);
+            if lcp.len() > input_buffer.len() {
+                *input_buffer = lcp;
+                true
+            } else {
+                false
+            }
+        }
+    }
+}
+
+/// Find the longest common prefix of a set of strings.
+fn longest_common_prefix(strings: &[&str]) -> String {
+    if strings.is_empty() {
+        return String::new();
+    }
+    let first = strings[0];
+    let mut len = first.len();
+    for s in &strings[1..] {
+        len = first
+            .chars()
+            .zip(s.chars())
+            .take(len)
+            .take_while(|(a, b)| a == b)
+            .count();
+    }
+    first[..first
+        .char_indices()
+        .nth(len)
+        .map_or(first.len(), |(i, _)| i)]
+        .to_string()
+}
+
 /// Handle a key event against the current input buffer and history.
 ///
-/// Modifies `input_buffer` in place (for character input, backspace, history).
+/// Modifies `input_buffer` in place (for character input, backspace, history, tab).
 /// Returns an `InputAction` describing what the TUI should do.
 pub fn handle_key(
     event: KeyEvent,
@@ -127,6 +202,12 @@ pub fn handle_key(
     match (event.modifiers, event.code) {
         // Quit
         (KeyModifiers::CONTROL, KeyCode::Char('c')) => InputAction::Quit,
+
+        // Tab completion
+        (_, KeyCode::Tab) => {
+            tab_complete(input_buffer);
+            InputAction::None
+        }
 
         // Submit
         (_, KeyCode::Enter) => {
@@ -189,6 +270,12 @@ fn parse_slash_command(text: &str) -> Option<SlashCmd> {
 
     let parts: Vec<&str> = text.split_whitespace().collect();
 
+    match parts.first().copied() {
+        Some("/exit") => return Some(SlashCmd::Exit),
+        Some("/login") => return Some(SlashCmd::Login),
+        _ => {}
+    }
+
     // /persona portrait size <size>
     if parts.len() == 4 && parts[0] == "/persona" && parts[1] == "portrait" && parts[2] == "size" {
         let size = parts[3].to_lowercase();
@@ -203,6 +290,16 @@ fn parse_slash_command(text: &str) -> Option<SlashCmd> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_exit() {
+        assert_eq!(parse_slash_command("/exit"), Some(SlashCmd::Exit));
+    }
+
+    #[test]
+    fn parse_login() {
+        assert_eq!(parse_slash_command("/login"), Some(SlashCmd::Login));
+    }
 
     #[test]
     fn parse_portrait_size_command() {
@@ -226,6 +323,54 @@ mod tests {
     }
 
     #[test]
+    fn tab_complete_single_match() {
+        let mut buf = "/ex".to_string();
+        assert!(tab_complete(&mut buf));
+        assert_eq!(buf, "/exit");
+    }
+
+    #[test]
+    fn tab_complete_common_prefix() {
+        let mut buf = "/persona portrait size ".to_string();
+        // All four size variants match — no common prefix beyond input
+        assert!(!tab_complete(&mut buf));
+    }
+
+    #[test]
+    fn tab_complete_partial_prefix() {
+        let mut buf = "/per".to_string();
+        assert!(tab_complete(&mut buf));
+        assert_eq!(buf, "/persona portrait size ");
+    }
+
+    #[test]
+    fn tab_complete_no_match() {
+        let mut buf = "/xyz".to_string();
+        assert!(!tab_complete(&mut buf));
+        assert_eq!(buf, "/xyz");
+    }
+
+    #[test]
+    fn tab_complete_non_slash_ignored() {
+        let mut buf = "hello".to_string();
+        assert!(!tab_complete(&mut buf));
+        assert_eq!(buf, "hello");
+    }
+
+    #[test]
+    fn tab_complete_exact_match_no_change() {
+        let mut buf = "/exit".to_string();
+        assert!(!tab_complete(&mut buf));
+    }
+
+    #[test]
+    fn tab_complete_login() {
+        let mut buf = "/lo".to_string();
+        assert!(tab_complete(&mut buf));
+        assert_eq!(buf, "/login");
+    }
+
+    #[test]
     fn history_prev_cycles_backward() {
         let mut h = InputHistory::new();
         h.push("first".to_string());
@@ -235,7 +380,6 @@ mod tests {
         assert_eq!(h.prev("current"), Some("third"));
         assert_eq!(h.prev("current"), Some("second"));
         assert_eq!(h.prev("current"), Some("first"));
-        // At oldest — stays
         assert_eq!(h.prev("current"), Some("first"));
     }
 
@@ -245,11 +389,9 @@ mod tests {
         h.push("first".to_string());
         h.push("second".to_string());
 
-        // Browse back
         h.prev("my draft");
         h.prev("my draft");
 
-        // Browse forward
         match h.newer() {
             NextResult::Entry(s) => assert_eq!(s, "second"),
             _ => panic!("expected Entry"),

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -21,6 +21,110 @@ const LOCAL_COMMANDS: &[&str] = &[
     "/persona portrait bottom",
 ];
 
+// ── InputState ───────────────────────────────────────────────────────────
+
+/// Input buffer with cursor position for mid-line editing.
+#[derive(Debug, Default)]
+pub struct InputState {
+    pub buffer: String,
+    pub cursor: usize,
+}
+
+impl InputState {
+    /// Insert a character at the cursor position.
+    pub fn insert(&mut self, c: char) {
+        let byte_pos = self.byte_offset();
+        self.buffer.insert(byte_pos, c);
+        self.cursor += 1;
+    }
+
+    /// Delete the character before the cursor (backspace).
+    pub fn delete_back(&mut self) {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+            let byte_pos = self.byte_offset();
+            self.buffer.remove(byte_pos);
+        }
+    }
+
+    /// Delete from cursor back to the previous word boundary (Ctrl+W).
+    pub fn delete_word_back(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+        let chars: Vec<char> = self.buffer.chars().collect();
+        let mut new_cursor = self.cursor;
+        // Skip trailing whitespace
+        while new_cursor > 0 && chars[new_cursor - 1].is_whitespace() {
+            new_cursor -= 1;
+        }
+        // Skip word characters
+        while new_cursor > 0 && !chars[new_cursor - 1].is_whitespace() {
+            new_cursor -= 1;
+        }
+        let start_byte = self.char_to_byte(new_cursor);
+        let end_byte = self.byte_offset();
+        self.buffer.drain(start_byte..end_byte);
+        self.cursor = new_cursor;
+    }
+
+    /// Clear the entire buffer (Ctrl+U).
+    pub fn clear(&mut self) {
+        self.buffer.clear();
+        self.cursor = 0;
+    }
+
+    /// Move cursor to start of line (Ctrl+A / Home).
+    pub fn home(&mut self) {
+        self.cursor = 0;
+    }
+
+    /// Move cursor to end of line (Ctrl+E / End).
+    pub fn end(&mut self) {
+        self.cursor = self.buffer.chars().count();
+    }
+
+    /// Move cursor left one character.
+    pub fn move_left(&mut self) {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+        }
+    }
+
+    /// Move cursor right one character.
+    pub fn move_right(&mut self) {
+        if self.cursor < self.buffer.chars().count() {
+            self.cursor += 1;
+        }
+    }
+
+    /// Set buffer content and move cursor to end.
+    pub fn set(&mut self, text: &str) {
+        self.buffer = text.to_string();
+        self.cursor = self.buffer.chars().count();
+    }
+
+    /// Get the trimmed text content.
+    pub fn text(&self) -> String {
+        self.buffer.trim().to_string()
+    }
+
+    /// Byte offset for the current cursor position.
+    fn byte_offset(&self) -> usize {
+        self.char_to_byte(self.cursor)
+    }
+
+    /// Convert char index to byte index.
+    fn char_to_byte(&self, char_idx: usize) -> usize {
+        self.buffer
+            .char_indices()
+            .nth(char_idx)
+            .map_or(self.buffer.len(), |(i, _)| i)
+    }
+}
+
+// ── Actions ──────────────────────────────────────────────────────────────
+
 /// Action resulting from a key press.
 #[derive(Debug)]
 pub enum InputAction {
@@ -36,6 +140,10 @@ pub enum InputAction {
     PageDown,
     /// Scroll to bottom of conversation.
     ScrollEnd,
+    /// Scroll conversation up one line (mouse wheel).
+    ScrollUp,
+    /// Scroll conversation down one line (mouse wheel).
+    ScrollDown,
     /// Toggle expanded output for most recent completed tool call.
     ToggleExpand,
     /// Cycle permission mode (Shift+Tab).
@@ -44,6 +152,10 @@ pub enum InputAction {
     PermissionAllow,
     /// Deny pending permission request.
     PermissionDeny,
+    /// Toggle thinking block display (Alt+T).
+    ToggleThinking,
+    /// Open external editor for input (Ctrl+G).
+    OpenEditor,
     /// No action (key consumed but no effect).
     None,
 }
@@ -51,29 +163,20 @@ pub enum InputAction {
 /// Parsed slash commands.
 #[derive(Debug, PartialEq)]
 pub enum SlashCmd {
-    /// Exit the TUI.
     Exit,
-    /// Show auth/login info.
     Login,
-    /// Clear conversation display.
     Clear,
-    /// Show available commands and keybindings.
     Help,
-    /// Show session cost from metrics.
     Cost,
-    /// Set portrait size.
     PortraitSize(String),
-    /// Toggle portrait on/off.
     PortraitToggle(bool),
-    /// Move portrait position (top/bottom).
     PortraitMove(String),
-    /// Forward to Claude Code as a user message (handles /compact, /model, etc.).
     ForwardToAgent(String),
-    /// Unknown slash command.
     Unknown(String),
 }
 
-/// Input history with up/down arrow cycling.
+// ── History ──────────────────────────────────────────────────────────────
+
 #[derive(Default)]
 pub struct InputHistory {
     entries: Vec<String>,
@@ -138,30 +241,27 @@ pub enum NextResult<'a> {
     NotBrowsing,
 }
 
+// ── Tab completion ───────────────────────────────────────────────────────
+
 /// Tab-complete slash commands or @ file paths.
-///
-/// For slash commands: merges static local commands with dynamic commands
-/// from system/init. For @ file paths: completes from the current directory.
-pub fn tab_complete(input_buffer: &mut String, dynamic_commands: &[String]) -> bool {
+pub fn tab_complete(input: &mut InputState, dynamic_commands: &[String]) -> bool {
     // @ file path completion
-    if let Some(at_pos) = input_buffer.rfind('@') {
-        let partial = &input_buffer[at_pos + 1..];
+    if let Some(at_pos) = input.buffer.rfind('@') {
+        let partial = &input.buffer[at_pos + 1..];
         if let Some(completed) = complete_file_path(partial) {
-            let prefix = input_buffer[..at_pos + 1].to_string();
-            *input_buffer = format!("{prefix}{completed}");
+            let prefix = input.buffer[..at_pos + 1].to_string();
+            input.set(&format!("{prefix}{completed}"));
             return true;
         }
         return false;
     }
 
     // Slash command completion
-    if !input_buffer.starts_with('/') {
+    if !input.buffer.starts_with('/') {
         return false;
     }
 
-    let prefix = input_buffer.as_str();
-
-    // Build combined command list: local + dynamic
+    let prefix = input.buffer.as_str();
     let mut all_commands: Vec<&str> = LOCAL_COMMANDS.to_vec();
     for cmd in dynamic_commands {
         if !all_commands.contains(&cmd.as_str()) {
@@ -178,13 +278,13 @@ pub fn tab_complete(input_buffer: &mut String, dynamic_commands: &[String]) -> b
     match matches.len() {
         0 => false,
         1 => {
-            *input_buffer = matches[0].to_string();
+            input.set(matches[0]);
             true
         }
         _ => {
             let lcp = longest_common_prefix(&matches);
-            if lcp.len() > input_buffer.len() {
-                *input_buffer = lcp;
+            if lcp.len() > input.buffer.len() {
+                input.set(&lcp);
                 true
             } else {
                 false
@@ -193,7 +293,6 @@ pub fn tab_complete(input_buffer: &mut String, dynamic_commands: &[String]) -> b
     }
 }
 
-/// Complete a file path from the current directory.
 fn complete_file_path(partial: &str) -> Option<String> {
     if partial.is_empty() {
         return None;
@@ -218,7 +317,6 @@ fn complete_file_path(partial: &str) -> Option<String> {
                 } else {
                     format!("{dir}{name}")
                 };
-                // Append / for directories
                 if entry.file_type().ok()?.is_dir() {
                     Some(format!("{full}/"))
                 } else {
@@ -236,7 +334,6 @@ fn complete_file_path(partial: &str) -> Option<String> {
         0 => None,
         1 => Some(matches.into_iter().next().expect("checked len")),
         _ => {
-            // Complete to longest common prefix
             let refs: Vec<&str> = matches.iter().map(String::as_str).collect();
             let lcp = longest_common_prefix(&refs);
             if lcp.len() > partial.len() {
@@ -269,10 +366,12 @@ fn longest_common_prefix(strings: &[&str]) -> String {
         .to_string()
 }
 
-/// Handle a key event against the current input buffer and history.
+// ── Key handling ─────────────────────────────────────────────────────────
+
+/// Handle a key event against the input state and history.
 pub fn handle_key(
     event: KeyEvent,
-    input_buffer: &mut String,
+    input: &mut InputState,
     history: &mut InputHistory,
     has_permission_prompt: bool,
     dynamic_commands: &[String],
@@ -281,26 +380,46 @@ pub fn handle_key(
         // Quit (always available)
         (KeyModifiers::CONTROL, KeyCode::Char('c')) => InputAction::Quit,
 
-        // Toggle expand tool output
+        // Ctrl shortcuts
         (KeyModifiers::CONTROL, KeyCode::Char('o')) => InputAction::ToggleExpand,
+        (KeyModifiers::CONTROL, KeyCode::Char('a')) => {
+            input.home();
+            InputAction::None
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('e')) => {
+            input.end();
+            InputAction::None
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('w')) => {
+            input.delete_word_back();
+            InputAction::None
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('u')) => {
+            input.clear();
+            InputAction::None
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('g')) => InputAction::OpenEditor,
+
+        // Alt shortcuts
+        (KeyModifiers::ALT, KeyCode::Char('t')) => InputAction::ToggleThinking,
 
         // Cycle permission mode (Shift+Tab)
         (KeyModifiers::SHIFT, KeyCode::BackTab) => InputAction::CyclePermissionMode,
 
-        // Permission prompt keys (when active, intercept before normal input)
+        // Permission prompt keys
         (_, KeyCode::Char('a')) if has_permission_prompt => InputAction::PermissionAllow,
         (_, KeyCode::Char('d')) if has_permission_prompt => InputAction::PermissionDeny,
 
-        // Tab completion (slash commands + @ file paths)
+        // Tab completion
         (_, KeyCode::Tab) => {
-            tab_complete(input_buffer, dynamic_commands);
+            tab_complete(input, dynamic_commands);
             InputAction::None
         }
 
         // Submit
         (_, KeyCode::Enter) => {
-            let text = input_buffer.trim().to_string();
-            input_buffer.clear();
+            let text = input.text();
+            input.clear();
             if text.is_empty() {
                 return InputAction::None;
             }
@@ -314,21 +433,37 @@ pub fn handle_key(
 
         // Editing
         (_, KeyCode::Backspace) => {
-            input_buffer.pop();
+            input.delete_back();
+            InputAction::None
+        }
+        (_, KeyCode::Delete) => {
+            // Delete char under cursor (move right then backspace)
+            if input.cursor < input.buffer.chars().count() {
+                input.move_right();
+                input.delete_back();
+            }
+            InputAction::None
+        }
+        (_, KeyCode::Left) => {
+            input.move_left();
+            InputAction::None
+        }
+        (_, KeyCode::Right) => {
+            input.move_right();
             InputAction::None
         }
 
         // History navigation
         (_, KeyCode::Up) => {
-            if let Some(entry) = history.prev(input_buffer) {
-                *input_buffer = entry.to_string();
+            if let Some(entry) = history.prev(&input.buffer) {
+                input.set(entry);
             }
             InputAction::None
         }
         (_, KeyCode::Down) => {
             match history.newer() {
-                NextResult::Entry(entry) => *input_buffer = entry.to_string(),
-                NextResult::Draft(draft) => *input_buffer = draft.to_string(),
+                NextResult::Entry(entry) => input.set(entry),
+                NextResult::Draft(draft) => input.set(draft),
                 NextResult::NotBrowsing => {}
             }
             InputAction::None
@@ -337,12 +472,20 @@ pub fn handle_key(
         // Scrolling
         (_, KeyCode::PageUp) => InputAction::PageUp,
         (_, KeyCode::PageDown) => InputAction::PageDown,
-        (_, KeyCode::End) => InputAction::ScrollEnd,
-        (_, KeyCode::Home) => InputAction::ScrollEnd,
+        (_, KeyCode::End) if input.buffer.is_empty() => InputAction::ScrollEnd,
+        (_, KeyCode::Home) if input.buffer.is_empty() => InputAction::ScrollEnd,
+        (_, KeyCode::End) => {
+            input.end();
+            InputAction::None
+        }
+        (_, KeyCode::Home) => {
+            input.home();
+            InputAction::None
+        }
 
         // Character input
         (_, KeyCode::Char(c)) => {
-            input_buffer.push(c);
+            input.insert(c);
             InputAction::None
         }
 
@@ -401,14 +544,105 @@ fn parse_slash_command(text: &str) -> Option<SlashCmd> {
         return Some(SlashCmd::ForwardToAgent(text.to_string()));
     }
 
-    // Any other / command from system/init available_slash_commands
-    // is also forwarded (MCP, skills, etc.)
     Some(SlashCmd::Unknown(text.to_string()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── InputState tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn input_insert_at_cursor() {
+        let mut s = InputState::default();
+        s.insert('a');
+        s.insert('b');
+        s.insert('c');
+        assert_eq!(s.buffer, "abc");
+        assert_eq!(s.cursor, 3);
+    }
+
+    #[test]
+    fn input_insert_mid_buffer() {
+        let mut s = InputState::default();
+        s.set("ac");
+        s.cursor = 1; // between a and c
+        s.insert('b');
+        assert_eq!(s.buffer, "abc");
+        assert_eq!(s.cursor, 2);
+    }
+
+    #[test]
+    fn input_delete_back() {
+        let mut s = InputState::default();
+        s.set("abc");
+        s.delete_back();
+        assert_eq!(s.buffer, "ab");
+        assert_eq!(s.cursor, 2);
+    }
+
+    #[test]
+    fn input_delete_back_at_start() {
+        let mut s = InputState::default();
+        s.set("abc");
+        s.cursor = 0;
+        s.delete_back();
+        assert_eq!(s.buffer, "abc"); // no change
+    }
+
+    #[test]
+    fn input_delete_word_back() {
+        let mut s = InputState::default();
+        s.set("hello world");
+        s.delete_word_back();
+        assert_eq!(s.buffer, "hello ");
+        assert_eq!(s.cursor, 6);
+    }
+
+    #[test]
+    fn input_delete_word_back_multiple_spaces() {
+        let mut s = InputState::default();
+        s.set("hello   world");
+        s.cursor = 8; // in the spaces
+        s.delete_word_back();
+        assert_eq!(s.buffer, "world");
+        assert_eq!(s.cursor, 0);
+    }
+
+    #[test]
+    fn input_home_end() {
+        let mut s = InputState::default();
+        s.set("hello");
+        assert_eq!(s.cursor, 5);
+        s.home();
+        assert_eq!(s.cursor, 0);
+        s.end();
+        assert_eq!(s.cursor, 5);
+    }
+
+    #[test]
+    fn input_move_left_right() {
+        let mut s = InputState::default();
+        s.set("abc");
+        s.move_left();
+        assert_eq!(s.cursor, 2);
+        s.move_left();
+        assert_eq!(s.cursor, 1);
+        s.move_right();
+        assert_eq!(s.cursor, 2);
+    }
+
+    #[test]
+    fn input_clear() {
+        let mut s = InputState::default();
+        s.set("hello");
+        s.clear();
+        assert_eq!(s.buffer, "");
+        assert_eq!(s.cursor, 0);
+    }
+
+    // ── Slash command tests ──────────────────────────────────────────────
 
     #[test]
     fn parse_exit() {
@@ -418,11 +652,6 @@ mod tests {
     #[test]
     fn parse_quit_alias() {
         assert_eq!(parse_slash_command("/quit"), Some(SlashCmd::Exit));
-    }
-
-    #[test]
-    fn parse_login() {
-        assert_eq!(parse_slash_command("/login"), Some(SlashCmd::Login));
     }
 
     #[test]
@@ -449,7 +678,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_portrait_size_command() {
+    fn parse_portrait_size() {
         match parse_slash_command("/persona portrait size large") {
             Some(SlashCmd::PortraitSize(s)) => assert_eq!(s, "large"),
             other => panic!("expected PortraitSize, got {other:?}"),
@@ -457,7 +686,19 @@ mod tests {
     }
 
     #[test]
-    fn parse_unknown_slash_command() {
+    fn parse_portrait_toggle() {
+        assert_eq!(
+            parse_slash_command("/persona portrait on"),
+            Some(SlashCmd::PortraitToggle(true))
+        );
+        assert_eq!(
+            parse_slash_command("/persona portrait off"),
+            Some(SlashCmd::PortraitToggle(false))
+        );
+    }
+
+    #[test]
+    fn parse_unknown() {
         match parse_slash_command("/unknown") {
             Some(SlashCmd::Unknown(s)) => assert_eq!(s, "/unknown"),
             other => panic!("expected Unknown, got {other:?}"),
@@ -469,61 +710,41 @@ mod tests {
         assert!(parse_slash_command("hello").is_none());
     }
 
-    #[test]
-    fn tab_complete_single_match() {
-        let mut buf = "/ex".to_string();
-        assert!(tab_complete(&mut buf, &[]));
-        assert_eq!(buf, "/exit");
-    }
+    // ── Tab completion tests ─────────────────────────────────────────────
 
     #[test]
-    fn tab_complete_common_prefix() {
-        let mut buf = "/persona portrait size ".to_string();
-        assert!(!tab_complete(&mut buf, &[]));
+    fn tab_complete_single_match() {
+        let mut input = InputState::default();
+        input.set("/ex");
+        assert!(tab_complete(&mut input, &[]));
+        assert_eq!(input.buffer, "/exit");
     }
 
     #[test]
     fn tab_complete_partial_prefix() {
-        let mut buf = "/per".to_string();
-        assert!(tab_complete(&mut buf, &[]));
-        // Matches all /persona portrait variants (size, on, off, top, bottom)
-        assert_eq!(buf, "/persona portrait ");
+        let mut input = InputState::default();
+        input.set("/per");
+        assert!(tab_complete(&mut input, &[]));
+        assert_eq!(input.buffer, "/persona portrait ");
     }
 
     #[test]
     fn tab_complete_no_match() {
-        let mut buf = "/xyz".to_string();
-        assert!(!tab_complete(&mut buf, &[]));
-        assert_eq!(buf, "/xyz");
-    }
-
-    #[test]
-    fn tab_complete_non_slash_ignored() {
-        let mut buf = "hello".to_string();
-        assert!(!tab_complete(&mut buf, &[]));
-        assert_eq!(buf, "hello");
-    }
-
-    #[test]
-    fn tab_complete_exact_match_no_change() {
-        let mut buf = "/exit".to_string();
-        assert!(!tab_complete(&mut buf, &[]));
+        let mut input = InputState::default();
+        input.set("/xyz");
+        assert!(!tab_complete(&mut input, &[]));
     }
 
     #[test]
     fn tab_complete_with_dynamic_commands() {
         let dynamic = vec!["/my-custom-cmd".to_string()];
-        let mut buf = "/my".to_string();
-        assert!(tab_complete(&mut buf, &dynamic));
-        assert_eq!(buf, "/my-custom-cmd");
+        let mut input = InputState::default();
+        input.set("/my");
+        assert!(tab_complete(&mut input, &dynamic));
+        assert_eq!(input.buffer, "/my-custom-cmd");
     }
 
-    #[test]
-    fn tab_complete_login() {
-        let mut buf = "/lo".to_string();
-        assert!(tab_complete(&mut buf, &[]));
-        assert_eq!(buf, "/login");
-    }
+    // ── History tests ────────────────────────────────────────────────────
 
     #[test]
     fn history_prev_cycles_backward() {
@@ -539,7 +760,7 @@ mod tests {
     }
 
     #[test]
-    fn history_next_cycles_forward_and_restores_draft() {
+    fn history_next_restores_draft() {
         let mut h = InputHistory::new();
         h.push("first".to_string());
         h.push("second".to_string());
@@ -560,7 +781,6 @@ mod tests {
     #[test]
     fn history_skips_duplicates() {
         let mut h = InputHistory::new();
-        h.push("same".to_string());
         h.push("same".to_string());
         h.push("same".to_string());
         assert_eq!(h.entries.len(), 1);

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -1,4 +1,4 @@
-//! Key handling and slash command parsing for the TUI.
+//! Key handling, slash command parsing, and input history for the TUI.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -11,10 +11,6 @@ pub enum InputAction {
     SlashCommand(SlashCmd),
     /// Quit the TUI.
     Quit,
-    /// Scroll conversation up one line.
-    ScrollUp,
-    /// Scroll conversation down one line.
-    ScrollDown,
     /// Scroll conversation up one page.
     PageUp,
     /// Scroll conversation down one page.
@@ -34,11 +30,100 @@ pub enum SlashCmd {
     Unknown(String),
 }
 
-/// Handle a key event against the current input buffer.
+/// Input history with up/down arrow cycling.
 ///
-/// Modifies `input_buffer` in place (for character input, backspace).
+/// Stores previous inputs and allows browsing through them.
+/// When browsing starts, the current draft is saved and restored
+/// when the user cycles past the newest entry.
+#[derive(Default)]
+pub struct InputHistory {
+    entries: Vec<String>,
+    /// Current position in history. `None` means not browsing.
+    position: Option<usize>,
+    /// Saved draft from when browsing started.
+    draft: String,
+}
+
+impl InputHistory {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a submitted input.
+    pub fn push(&mut self, entry: String) {
+        // Don't store empty or duplicate-of-last entries
+        if entry.is_empty() || self.entries.last().is_some_and(|last| last == &entry) {
+            self.position = None;
+            return;
+        }
+        self.entries.push(entry);
+        self.position = None;
+    }
+
+    /// Navigate to an older entry (up arrow). Returns the text to display.
+    pub fn prev(&mut self, current_input: &str) -> Option<&str> {
+        if self.entries.is_empty() {
+            return None;
+        }
+        match self.position {
+            None => {
+                // Start browsing — save current input as draft
+                self.draft = current_input.to_string();
+                let idx = self.entries.len() - 1;
+                self.position = Some(idx);
+                Some(&self.entries[idx])
+            }
+            Some(0) => {
+                // Already at oldest — stay put
+                Some(&self.entries[0])
+            }
+            Some(idx) => {
+                let new_idx = idx - 1;
+                self.position = Some(new_idx);
+                Some(&self.entries[new_idx])
+            }
+        }
+    }
+
+    /// Navigate to a newer entry (down arrow). Returns the text to display,
+    /// or `None` if we've cycled past the newest entry (restores draft).
+    pub fn newer(&mut self) -> NextResult<'_> {
+        match self.position {
+            None => NextResult::NotBrowsing,
+            Some(idx) => {
+                if idx + 1 >= self.entries.len() {
+                    // Past newest — restore draft
+                    self.position = None;
+                    NextResult::Draft(&self.draft)
+                } else {
+                    let new_idx = idx + 1;
+                    self.position = Some(new_idx);
+                    NextResult::Entry(&self.entries[new_idx])
+                }
+            }
+        }
+    }
+}
+
+/// Result of navigating forward in history.
+pub enum NextResult<'a> {
+    /// An older entry.
+    Entry(&'a str),
+    /// Restored draft (cycled past newest).
+    Draft(&'a str),
+    /// Not currently browsing history.
+    NotBrowsing,
+}
+
+/// Handle a key event against the current input buffer and history.
+///
+/// Modifies `input_buffer` in place (for character input, backspace, history).
 /// Returns an `InputAction` describing what the TUI should do.
-pub fn handle_key(event: KeyEvent, input_buffer: &mut String) -> InputAction {
+pub fn handle_key(
+    event: KeyEvent,
+    input_buffer: &mut String,
+    history: &mut InputHistory,
+) -> InputAction {
     match (event.modifiers, event.code) {
         // Quit
         (KeyModifiers::CONTROL, KeyCode::Char('c')) => InputAction::Quit,
@@ -50,6 +135,7 @@ pub fn handle_key(event: KeyEvent, input_buffer: &mut String) -> InputAction {
             if text.is_empty() {
                 return InputAction::None;
             }
+            history.push(text.clone());
             if let Some(cmd) = parse_slash_command(&text) {
                 InputAction::SlashCommand(cmd)
             } else {
@@ -63,9 +149,23 @@ pub fn handle_key(event: KeyEvent, input_buffer: &mut String) -> InputAction {
             InputAction::None
         }
 
-        // Scrolling
-        (_, KeyCode::Up) => InputAction::ScrollUp,
-        (_, KeyCode::Down) => InputAction::ScrollDown,
+        // History navigation
+        (_, KeyCode::Up) => {
+            if let Some(entry) = history.prev(input_buffer) {
+                *input_buffer = entry.to_string();
+            }
+            InputAction::None
+        }
+        (_, KeyCode::Down) => {
+            match history.newer() {
+                NextResult::Entry(entry) => *input_buffer = entry.to_string(),
+                NextResult::Draft(draft) => *input_buffer = draft.to_string(),
+                NextResult::NotBrowsing => {}
+            }
+            InputAction::None
+        }
+
+        // Scrolling (page-level only — up/down are for history)
         (_, KeyCode::PageUp) => InputAction::PageUp,
         (_, KeyCode::PageDown) => InputAction::PageDown,
         (_, KeyCode::End) => InputAction::ScrollEnd,
@@ -123,5 +223,56 @@ mod tests {
     #[test]
     fn non_slash_returns_none() {
         assert!(parse_slash_command("hello").is_none());
+    }
+
+    #[test]
+    fn history_prev_cycles_backward() {
+        let mut h = InputHistory::new();
+        h.push("first".to_string());
+        h.push("second".to_string());
+        h.push("third".to_string());
+
+        assert_eq!(h.prev("current"), Some("third"));
+        assert_eq!(h.prev("current"), Some("second"));
+        assert_eq!(h.prev("current"), Some("first"));
+        // At oldest — stays
+        assert_eq!(h.prev("current"), Some("first"));
+    }
+
+    #[test]
+    fn history_next_cycles_forward_and_restores_draft() {
+        let mut h = InputHistory::new();
+        h.push("first".to_string());
+        h.push("second".to_string());
+
+        // Browse back
+        h.prev("my draft");
+        h.prev("my draft");
+
+        // Browse forward
+        match h.newer() {
+            NextResult::Entry(s) => assert_eq!(s, "second"),
+            _ => panic!("expected Entry"),
+        }
+        match h.newer() {
+            NextResult::Draft(s) => assert_eq!(s, "my draft"),
+            _ => panic!("expected Draft"),
+        }
+    }
+
+    #[test]
+    fn history_skips_duplicates() {
+        let mut h = InputHistory::new();
+        h.push("same".to_string());
+        h.push("same".to_string());
+        h.push("same".to_string());
+        assert_eq!(h.entries.len(), 1);
+    }
+
+    #[test]
+    fn history_skips_empty() {
+        let mut h = InputHistory::new();
+        h.push(String::new());
+        assert!(h.entries.is_empty());
     }
 }

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -144,8 +144,10 @@ pub enum InputAction {
     ScrollUp,
     /// Scroll conversation down one line (mouse wheel).
     ScrollDown,
-    /// Toggle expanded output for most recent completed tool call.
+    /// Toggle expanded output for most recent completed tool call (Ctrl+X).
     ToggleExpand,
+    /// Cycle transcript mode: normal → transcript → focus (Ctrl+O).
+    CycleTranscript,
     /// Cycle permission mode (Shift+Tab).
     CyclePermissionMode,
     /// Allow pending permission request.
@@ -387,7 +389,8 @@ pub fn handle_key(
         (KeyModifiers::CONTROL, KeyCode::Char('c')) => InputAction::Quit,
 
         // Ctrl shortcuts
-        (KeyModifiers::CONTROL, KeyCode::Char('o')) => InputAction::ToggleExpand,
+        (KeyModifiers::CONTROL, KeyCode::Char('o')) => InputAction::CycleTranscript,
+        (KeyModifiers::CONTROL, KeyCode::Char('x')) => InputAction::ToggleExpand,
         (KeyModifiers::CONTROL, KeyCode::Char('a')) => {
             input.home();
             InputAction::None

--- a/src/tui/layout.rs
+++ b/src/tui/layout.rs
@@ -1,23 +1,4 @@
 //! Layout computation for the TUI.
-//!
-//! ```text
-//! ┌─────────────────────────────────────────┐
-//! │ CONVERSATION VIEWPORT    ┌────────────┐ │
-//! │ (scrollable, full width) │  PORTRAIT  │ │
-//! │                          │  (overlay) │ │
-//! │                          └────────────┘ │
-//! │                                         │
-//! ├─────────────────────────────────────────┤  ← optional permission prompt
-//! │ ┌─ Permission Required ───────────────┐ │
-//! │ │  Tool: Edit                         │ │
-//! │ │  [a] Allow  [d] Deny               │ │
-//! │ └────────────────────────────────────-┘ │
-//! ├─────────────────────────────────────────┤
-//! │ > INPUT AREA                            │
-//! ├─────────────────────────────────────────┤
-//! │ STATUS BAR                              │
-//! └─────────────────────────────────────────┘
-//! ```
 
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 
@@ -35,21 +16,19 @@ const STATUS_HEIGHT: u16 = 1;
 /// Permission prompt height in rows (when active).
 const PERMISSION_HEIGHT: u16 = 6;
 
+/// Portrait margin from the terminal edge (right and top/bottom).
+const PORTRAIT_MARGIN: u16 = 1;
+
 /// Computed layout areas for a single frame.
 pub struct TuiLayout {
-    /// Conversation viewport (scrollable text, full width).
     pub conversation: Rect,
-    /// Portrait overlay area (upper-right of conversation, may be zero-size).
     pub portrait: Rect,
-    /// Permission prompt area (above input, zero-size when no prompt active).
     pub permission_prompt: Rect,
-    /// User input area.
     pub input: Rect,
-    /// Status bar.
     pub status: Rect,
 }
 
-/// Compute layout for the given terminal size and portrait configuration.
+/// Compute layout for the given terminal size.
 pub fn compute_layout(
     area: Rect,
     portrait_size: PortraitSize,
@@ -71,29 +50,16 @@ pub fn compute_layout(
         let conversation = vertical[0];
         let input = vertical[1];
 
-        let portrait = if has_portrait && area.width >= MIN_WIDTH_FOR_PORTRAIT {
-            let pw = portrait_column_width(portrait_size, area.width);
-            let ph = (pw * 3 / 4).min(conversation.height / 2).max(4);
-            let x = conversation.x + conversation.width.saturating_sub(pw);
-            let y = match portrait_position {
-                PortraitPosition::TopRight => conversation.y,
-                PortraitPosition::BottomRight => {
-                    conversation.y + conversation.height.saturating_sub(ph)
-                }
-            };
-            Rect {
-                x,
-                y,
-                width: pw,
-                height: ph,
-            }
-        } else {
-            Rect::default()
-        };
-
         return TuiLayout {
+            portrait: compute_portrait_rect(
+                portrait_size,
+                portrait_position,
+                has_portrait,
+                area.width,
+                conversation,
+                input,
+            ),
             conversation,
-            portrait,
             permission_prompt: Rect::default(),
             input,
             status: Rect::default(),
@@ -127,33 +93,65 @@ pub fn compute_layout(
         (vertical[0], Rect::default(), vertical[1], vertical[2])
     };
 
-    // Portrait overlay — positioned in upper-right or lower-right of conversation
-    let portrait = if has_portrait && area.width >= MIN_WIDTH_FOR_PORTRAIT {
-        let pw = portrait_column_width(portrait_size, area.width);
-        let ph = (pw * 3 / 4).min(conversation.height / 2).max(4);
-        let x = conversation.x + conversation.width.saturating_sub(pw);
-        let y = match portrait_position {
-            PortraitPosition::TopRight => conversation.y,
-            PortraitPosition::BottomRight => {
-                conversation.y + conversation.height.saturating_sub(ph)
-            }
-        };
-        Rect {
-            x,
-            y,
-            width: pw,
-            height: ph,
-        }
-    } else {
-        Rect::default()
-    };
-
     TuiLayout {
+        portrait: compute_portrait_rect(
+            portrait_size,
+            portrait_position,
+            has_portrait,
+            area.width,
+            conversation,
+            input,
+        ),
         conversation,
-        portrait,
         permission_prompt,
         input,
         status,
+    }
+}
+
+/// Compute the portrait overlay Rect.
+///
+/// The portrait is always right-aligned with a small margin from the
+/// terminal edge. All sizes share the same right edge. Position:
+/// - TopRight: top-right corner of conversation, slight margin from top and right
+/// - BottomRight: bottom-right, just above the input area's top border
+fn compute_portrait_rect(
+    portrait_size: PortraitSize,
+    portrait_position: PortraitPosition,
+    has_portrait: bool,
+    terminal_width: u16,
+    conversation: Rect,
+    input: Rect,
+) -> Rect {
+    if !has_portrait || terminal_width < MIN_WIDTH_FOR_PORTRAIT {
+        return Rect::default();
+    }
+
+    let pw = portrait_column_width(portrait_size, terminal_width);
+    // Height proportional to width (roughly 4:3 aspect ratio for portraits)
+    let max_height = conversation.height.saturating_sub(PORTRAIT_MARGIN * 2);
+    let ph = (pw * 3 / 4).min(max_height).max(4);
+
+    // Right edge: flush to terminal right with margin
+    let x = conversation
+        .x
+        .saturating_add(conversation.width)
+        .saturating_sub(pw)
+        .saturating_sub(PORTRAIT_MARGIN);
+
+    let y = match portrait_position {
+        PortraitPosition::TopRight => conversation.y + PORTRAIT_MARGIN,
+        PortraitPosition::BottomRight => {
+            // Just above the input area's top border, with margin
+            input.y.saturating_sub(ph).saturating_sub(PORTRAIT_MARGIN)
+        }
+    };
+
+    Rect {
+        x,
+        y,
+        width: pw,
+        height: ph,
     }
 }
 

--- a/src/tui/layout.rs
+++ b/src/tui/layout.rs
@@ -21,7 +21,7 @@
 
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 
-use super::app::PortraitSize;
+use super::app::{PortraitPosition, PortraitSize};
 
 /// Minimum terminal width to show portrait overlay.
 const MIN_WIDTH_FOR_PORTRAIT: u16 = 60;
@@ -53,6 +53,7 @@ pub struct TuiLayout {
 pub fn compute_layout(
     area: Rect,
     portrait_size: PortraitSize,
+    portrait_position: PortraitPosition,
     has_portrait: bool,
     has_permission_prompt: bool,
 ) -> TuiLayout {
@@ -83,13 +84,20 @@ pub fn compute_layout(
         (vertical[0], Rect::default(), vertical[1], vertical[2])
     };
 
-    // Portrait is an overlay in the upper-right corner of the conversation area
+    // Portrait overlay — positioned in upper-right or lower-right of conversation
     let portrait = if has_portrait && area.width >= MIN_WIDTH_FOR_PORTRAIT {
         let pw = portrait_column_width(portrait_size, area.width);
         let ph = (pw * 3 / 4).min(conversation.height / 2).max(4);
+        let x = conversation.x + conversation.width.saturating_sub(pw);
+        let y = match portrait_position {
+            PortraitPosition::TopRight => conversation.y,
+            PortraitPosition::BottomRight => {
+                conversation.y + conversation.height.saturating_sub(ph)
+            }
+        };
         Rect {
-            x: conversation.x + conversation.width.saturating_sub(pw),
-            y: conversation.y,
+            x,
+            y,
             width: pw,
             height: ph,
         }

--- a/src/tui/layout.rs
+++ b/src/tui/layout.rs
@@ -1,0 +1,93 @@
+//! Layout computation for the TUI.
+//!
+//! ```text
+//! ┌─────────────────────────────┬──────────┐
+//! │ CONVERSATION VIEWPORT       │ PORTRAIT │
+//! │ (scrollable)                │ (upper   │
+//! │                             │  right)  │
+//! ├─────────────────────────────┴──────────┤
+//! │ > INPUT AREA                            │
+//! ├─────────────────────────────────────────┤
+//! │ STATUS BAR                              │
+//! └─────────────────────────────────────────┘
+//! ```
+
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+
+use super::app::PortraitSize;
+
+/// Minimum terminal width to show portrait column.
+const MIN_WIDTH_FOR_PORTRAIT: u16 = 60;
+
+/// Input area height in rows.
+const INPUT_HEIGHT: u16 = 3;
+
+/// Status bar height in rows.
+const STATUS_HEIGHT: u16 = 1;
+
+/// Computed layout areas for a single frame.
+pub struct TuiLayout {
+    /// Conversation viewport (scrollable text).
+    pub conversation: Rect,
+    /// Portrait area (upper-right, may be zero-size).
+    pub portrait: Rect,
+    /// User input area.
+    pub input: Rect,
+    /// Status bar.
+    pub status: Rect,
+}
+
+/// Compute layout for the given terminal size and portrait configuration.
+pub fn compute_layout(area: Rect, portrait_size: PortraitSize, has_portrait: bool) -> TuiLayout {
+    // Vertical split: main content | input | status
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(1),                // main content area
+            Constraint::Length(INPUT_HEIGHT),  // input
+            Constraint::Length(STATUS_HEIGHT), // status
+        ])
+        .split(area);
+
+    let main_area = vertical[0];
+    let input = vertical[1];
+    let status = vertical[2];
+
+    // Horizontal split of main area: conversation | portrait
+    let show_portrait = has_portrait && area.width >= MIN_WIDTH_FOR_PORTRAIT;
+
+    if show_portrait {
+        let portrait_width = portrait_column_width(portrait_size, area.width);
+        let horizontal = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Min(1),                 // conversation
+                Constraint::Length(portrait_width), // portrait
+            ])
+            .split(main_area);
+
+        TuiLayout {
+            conversation: horizontal[0],
+            portrait: horizontal[1],
+            input,
+            status,
+        }
+    } else {
+        TuiLayout {
+            conversation: main_area,
+            portrait: Rect::default(), // zero-size
+            input,
+            status,
+        }
+    }
+}
+
+/// Portrait column width for a given size setting.
+fn portrait_column_width(size: PortraitSize, terminal_width: u16) -> u16 {
+    match size {
+        PortraitSize::Small => 20,
+        PortraitSize::Medium => 32,
+        PortraitSize::Large => 48,
+        PortraitSize::Original => (terminal_width / 3).min(64),
+    }
+}

--- a/src/tui/layout.rs
+++ b/src/tui/layout.rs
@@ -1,11 +1,13 @@
 //! Layout computation for the TUI.
 //!
 //! ```text
-//! ┌─────────────────────────────┬──────────┐
-//! │ CONVERSATION VIEWPORT       │ PORTRAIT │
-//! │ (scrollable)                │ (upper   │
-//! │                             │  right)  │
-//! ├─────────────────────────────┴──────────┤
+//! ┌─────────────────────────────────────────┐
+//! │ CONVERSATION VIEWPORT    ┌────────────┐ │
+//! │ (scrollable, full width) │  PORTRAIT  │ │
+//! │                          │  (overlay) │ │
+//! │                          └────────────┘ │
+//! │                                         │
+//! ├─────────────────────────────────────────┤
 //! │ > INPUT AREA                            │
 //! ├─────────────────────────────────────────┤
 //! │ STATUS BAR                              │
@@ -16,7 +18,7 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 
 use super::app::PortraitSize;
 
-/// Minimum terminal width to show portrait column.
+/// Minimum terminal width to show portrait overlay.
 const MIN_WIDTH_FOR_PORTRAIT: u16 = 60;
 
 /// Input area height in rows.
@@ -27,9 +29,9 @@ const STATUS_HEIGHT: u16 = 1;
 
 /// Computed layout areas for a single frame.
 pub struct TuiLayout {
-    /// Conversation viewport (scrollable text).
+    /// Conversation viewport (scrollable text, full width).
     pub conversation: Rect,
-    /// Portrait area (upper-right, may be zero-size).
+    /// Portrait overlay area (upper-right of conversation, may be zero-size).
     pub portrait: Rect,
     /// User input area.
     pub input: Rect,
@@ -38,51 +40,49 @@ pub struct TuiLayout {
 }
 
 /// Compute layout for the given terminal size and portrait configuration.
+///
+/// The conversation viewport gets full width. The portrait is an overlay
+/// in the upper-right corner of the conversation area — it renders on top
+/// of the text, not beside it.
 pub fn compute_layout(area: Rect, portrait_size: PortraitSize, has_portrait: bool) -> TuiLayout {
-    // Vertical split: main content | input | status
+    // Vertical split: conversation | input | status
     let vertical = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(1),                // main content area
+            Constraint::Min(1),                // conversation (full width)
             Constraint::Length(INPUT_HEIGHT),  // input
             Constraint::Length(STATUS_HEIGHT), // status
         ])
         .split(area);
 
-    let main_area = vertical[0];
+    let conversation = vertical[0];
     let input = vertical[1];
     let status = vertical[2];
 
-    // Horizontal split of main area: conversation | portrait
-    let show_portrait = has_portrait && area.width >= MIN_WIDTH_FOR_PORTRAIT;
-
-    if show_portrait {
-        let portrait_width = portrait_column_width(portrait_size, area.width);
-        let horizontal = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([
-                Constraint::Min(1),                 // conversation
-                Constraint::Length(portrait_width), // portrait
-            ])
-            .split(main_area);
-
-        TuiLayout {
-            conversation: horizontal[0],
-            portrait: horizontal[1],
-            input,
-            status,
+    // Portrait is an overlay in the upper-right corner of the conversation area
+    let portrait = if has_portrait && area.width >= MIN_WIDTH_FOR_PORTRAIT {
+        let pw = portrait_column_width(portrait_size, area.width);
+        // Height: roughly match aspect ratio, cap at half the conversation height
+        let ph = (pw * 3 / 4).min(conversation.height / 2).max(4);
+        Rect {
+            x: conversation.x + conversation.width.saturating_sub(pw),
+            y: conversation.y,
+            width: pw,
+            height: ph,
         }
     } else {
-        TuiLayout {
-            conversation: main_area,
-            portrait: Rect::default(), // zero-size
-            input,
-            status,
-        }
+        Rect::default()
+    };
+
+    TuiLayout {
+        conversation,
+        portrait,
+        input,
+        status,
     }
 }
 
-/// Portrait column width for a given size setting.
+/// Portrait overlay width for a given size setting.
 fn portrait_column_width(size: PortraitSize, terminal_width: u16) -> u16 {
     match size {
         PortraitSize::Small => 20,

--- a/src/tui/layout.rs
+++ b/src/tui/layout.rs
@@ -41,7 +41,8 @@ pub fn compute_layout(
     // No left/right borders, so inner width = area width.
     // +2 for "> " prefix, +2 for borders (top + bottom).
     let text_cols = area.width; // no left/right borders
-    let text_with_prefix = input_len as u16 + 2; // "> " prefix
+    let capped_len = input_len.min(u16::MAX as usize - 2) as u16;
+    let text_with_prefix = capped_len + 2; // "> " prefix
     let text_lines = if text_cols == 0 {
         1
     } else {

--- a/src/tui/layout.rs
+++ b/src/tui/layout.rs
@@ -7,8 +7,11 @@ use super::app::{PortraitPosition, PortraitSize};
 /// Minimum terminal width to show portrait overlay.
 const MIN_WIDTH_FOR_PORTRAIT: u16 = 60;
 
-/// Input area height in rows.
-const INPUT_HEIGHT: u16 = 3;
+/// Minimum input area height in rows (1 border + 1 text + 1 border).
+const MIN_INPUT_HEIGHT: u16 = 3;
+
+/// Maximum input area height (cap growth to prevent eating the conversation).
+const MAX_INPUT_HEIGHT: u16 = 10;
 
 /// Status bar height in rows.
 const STATUS_HEIGHT: u16 = 1;
@@ -36,7 +39,18 @@ pub fn compute_layout(
     has_portrait: bool,
     has_permission_prompt: bool,
     focus_mode: bool,
+    input_len: usize,
 ) -> TuiLayout {
+    // Compute input height based on text length — grows as user types
+    // +2 for "> " prefix, +2 for borders (top + bottom)
+    let text_cols = area.width.saturating_sub(2); // available width inside borders
+    let text_with_prefix = input_len as u16 + 2; // "> " prefix
+    let text_lines = if text_cols == 0 {
+        1
+    } else {
+        (text_with_prefix / text_cols) + 1
+    };
+    let input_height = (text_lines + 2).clamp(MIN_INPUT_HEIGHT, MAX_INPUT_HEIGHT);
     // Focus mode: maximize conversation, minimal chrome
     if focus_mode {
         let vertical = Layout::default()
@@ -71,13 +85,13 @@ pub fn compute_layout(
         vec![
             Constraint::Min(1),                    // conversation
             Constraint::Length(PERMISSION_HEIGHT), // permission prompt
-            Constraint::Length(INPUT_HEIGHT),      // input
+            Constraint::Length(input_height),      // input
             Constraint::Length(STATUS_HEIGHT),     // status
         ]
     } else {
         vec![
             Constraint::Min(1),                // conversation
-            Constraint::Length(INPUT_HEIGHT),  // input
+            Constraint::Length(input_height),  // input
             Constraint::Length(STATUS_HEIGHT), // status
         ]
     };

--- a/src/tui/layout.rs
+++ b/src/tui/layout.rs
@@ -56,7 +56,50 @@ pub fn compute_layout(
     portrait_position: PortraitPosition,
     has_portrait: bool,
     has_permission_prompt: bool,
+    focus_mode: bool,
 ) -> TuiLayout {
+    // Focus mode: maximize conversation, minimal chrome
+    if focus_mode {
+        let vertical = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Min(1),    // conversation
+                Constraint::Length(1), // minimal input (no borders)
+            ])
+            .split(area);
+
+        let conversation = vertical[0];
+        let input = vertical[1];
+
+        let portrait = if has_portrait && area.width >= MIN_WIDTH_FOR_PORTRAIT {
+            let pw = portrait_column_width(portrait_size, area.width);
+            let ph = (pw * 3 / 4).min(conversation.height / 2).max(4);
+            let x = conversation.x + conversation.width.saturating_sub(pw);
+            let y = match portrait_position {
+                PortraitPosition::TopRight => conversation.y,
+                PortraitPosition::BottomRight => {
+                    conversation.y + conversation.height.saturating_sub(ph)
+                }
+            };
+            Rect {
+                x,
+                y,
+                width: pw,
+                height: ph,
+            }
+        } else {
+            Rect::default()
+        };
+
+        return TuiLayout {
+            conversation,
+            portrait,
+            permission_prompt: Rect::default(),
+            input,
+            status: Rect::default(),
+        };
+    }
+
     // Build constraints based on whether permission prompt is active
     let constraints = if has_permission_prompt {
         vec![

--- a/src/tui/layout.rs
+++ b/src/tui/layout.rs
@@ -2,10 +2,7 @@
 
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 
-use super::app::{PortraitPosition, PortraitSize};
-
-/// Minimum terminal width to show portrait overlay.
-const MIN_WIDTH_FOR_PORTRAIT: u16 = 60;
+use super::app::PortraitPosition;
 
 /// Minimum input area height in rows (1 border + 1 text + 1 border).
 const MIN_INPUT_HEIGHT: u16 = 3;
@@ -34,9 +31,8 @@ pub struct TuiLayout {
 /// Compute layout for the given terminal size.
 pub fn compute_layout(
     area: Rect,
-    portrait_size: PortraitSize,
     portrait_position: PortraitPosition,
-    has_portrait: bool,
+    portrait_cell_size: Option<(u16, u16)>,
     has_permission_prompt: bool,
     focus_mode: bool,
     input_len: usize,
@@ -67,10 +63,8 @@ pub fn compute_layout(
 
         return TuiLayout {
             portrait: compute_portrait_rect(
-                portrait_size,
                 portrait_position,
-                has_portrait,
-                area.width,
+                portrait_cell_size,
                 conversation,
                 input,
             ),
@@ -109,14 +103,7 @@ pub fn compute_layout(
     };
 
     TuiLayout {
-        portrait: compute_portrait_rect(
-            portrait_size,
-            portrait_position,
-            has_portrait,
-            area.width,
-            conversation,
-            input,
-        ),
+        portrait: compute_portrait_rect(portrait_position, portrait_cell_size, conversation, input),
         conversation,
         permission_prompt,
         input,
@@ -126,38 +113,35 @@ pub fn compute_layout(
 
 /// Compute the portrait overlay Rect.
 ///
-/// The portrait is always right-aligned with a small margin from the
-/// terminal edge. All sizes share the same right edge. Position:
-/// - TopRight: top-right corner of conversation, slight margin from top and right
-/// - BottomRight: bottom-right, just above the input area's top border
+/// Uses actual image cell dimensions for a tight fit. The right edge is
+/// always anchored at `terminal_width - PORTRAIT_MARGIN` regardless of
+/// portrait size. Position:
+/// - TopRight: anchored to top-right with margin
+/// - BottomRight: anchored just above the input area's top border
 fn compute_portrait_rect(
-    portrait_size: PortraitSize,
     portrait_position: PortraitPosition,
-    has_portrait: bool,
-    terminal_width: u16,
+    portrait_cell_size: Option<(u16, u16)>,
     conversation: Rect,
     input: Rect,
 ) -> Rect {
-    if !has_portrait || terminal_width < MIN_WIDTH_FOR_PORTRAIT {
+    let Some((pw, ph)) = portrait_cell_size else {
+        return Rect::default();
+    };
+
+    if pw == 0 || ph == 0 {
         return Rect::default();
     }
 
-    let pw = portrait_column_width(portrait_size, terminal_width);
-    // Height proportional to width (roughly 4:3 aspect ratio for portraits)
-    let max_height = conversation.height.saturating_sub(PORTRAIT_MARGIN * 2);
-    let ph = (pw * 3 / 4).min(max_height).max(4);
-
-    // Right edge: flush to terminal right with margin
-    let x = conversation
-        .x
-        .saturating_add(conversation.width)
+    // Right edge anchored to terminal right minus margin
+    let right_edge = conversation.x + conversation.width;
+    let x = right_edge
         .saturating_sub(pw)
         .saturating_sub(PORTRAIT_MARGIN);
 
     let y = match portrait_position {
         PortraitPosition::TopRight => conversation.y + PORTRAIT_MARGIN,
         PortraitPosition::BottomRight => {
-            // Just above the input area's top border, with margin
+            // Just above the input area's top border
             input.y.saturating_sub(ph).saturating_sub(PORTRAIT_MARGIN)
         }
     };
@@ -167,15 +151,5 @@ fn compute_portrait_rect(
         y,
         width: pw,
         height: ph,
-    }
-}
-
-/// Portrait overlay width for a given size setting.
-fn portrait_column_width(size: PortraitSize, terminal_width: u16) -> u16 {
-    match size {
-        PortraitSize::Small => 20,
-        PortraitSize::Medium => 32,
-        PortraitSize::Large => 48,
-        PortraitSize::Original => (terminal_width / 3).min(64),
     }
 }

--- a/src/tui/layout.rs
+++ b/src/tui/layout.rs
@@ -7,6 +7,11 @@
 //! │                          │  (overlay) │ │
 //! │                          └────────────┘ │
 //! │                                         │
+//! ├─────────────────────────────────────────┤  ← optional permission prompt
+//! │ ┌─ Permission Required ───────────────┐ │
+//! │ │  Tool: Edit                         │ │
+//! │ │  [a] Allow  [d] Deny               │ │
+//! │ └────────────────────────────────────-┘ │
 //! ├─────────────────────────────────────────┤
 //! │ > INPUT AREA                            │
 //! ├─────────────────────────────────────────┤
@@ -27,12 +32,17 @@ const INPUT_HEIGHT: u16 = 3;
 /// Status bar height in rows.
 const STATUS_HEIGHT: u16 = 1;
 
+/// Permission prompt height in rows (when active).
+const PERMISSION_HEIGHT: u16 = 6;
+
 /// Computed layout areas for a single frame.
 pub struct TuiLayout {
     /// Conversation viewport (scrollable text, full width).
     pub conversation: Rect,
     /// Portrait overlay area (upper-right of conversation, may be zero-size).
     pub portrait: Rect,
+    /// Permission prompt area (above input, zero-size when no prompt active).
+    pub permission_prompt: Rect,
     /// User input area.
     pub input: Rect,
     /// Status bar.
@@ -40,29 +50,42 @@ pub struct TuiLayout {
 }
 
 /// Compute layout for the given terminal size and portrait configuration.
-///
-/// The conversation viewport gets full width. The portrait is an overlay
-/// in the upper-right corner of the conversation area — it renders on top
-/// of the text, not beside it.
-pub fn compute_layout(area: Rect, portrait_size: PortraitSize, has_portrait: bool) -> TuiLayout {
-    // Vertical split: conversation | input | status
-    let vertical = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Min(1),                // conversation (full width)
+pub fn compute_layout(
+    area: Rect,
+    portrait_size: PortraitSize,
+    has_portrait: bool,
+    has_permission_prompt: bool,
+) -> TuiLayout {
+    // Build constraints based on whether permission prompt is active
+    let constraints = if has_permission_prompt {
+        vec![
+            Constraint::Min(1),                    // conversation
+            Constraint::Length(PERMISSION_HEIGHT), // permission prompt
+            Constraint::Length(INPUT_HEIGHT),      // input
+            Constraint::Length(STATUS_HEIGHT),     // status
+        ]
+    } else {
+        vec![
+            Constraint::Min(1),                // conversation
             Constraint::Length(INPUT_HEIGHT),  // input
             Constraint::Length(STATUS_HEIGHT), // status
-        ])
+        ]
+    };
+
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
         .split(area);
 
-    let conversation = vertical[0];
-    let input = vertical[1];
-    let status = vertical[2];
+    let (conversation, permission_prompt, input, status) = if has_permission_prompt {
+        (vertical[0], vertical[1], vertical[2], vertical[3])
+    } else {
+        (vertical[0], Rect::default(), vertical[1], vertical[2])
+    };
 
     // Portrait is an overlay in the upper-right corner of the conversation area
     let portrait = if has_portrait && area.width >= MIN_WIDTH_FOR_PORTRAIT {
         let pw = portrait_column_width(portrait_size, area.width);
-        // Height: roughly match aspect ratio, cap at half the conversation height
         let ph = (pw * 3 / 4).min(conversation.height / 2).max(4);
         Rect {
             x: conversation.x + conversation.width.saturating_sub(pw),
@@ -77,6 +100,7 @@ pub fn compute_layout(area: Rect, portrait_size: PortraitSize, has_portrait: boo
     TuiLayout {
         conversation,
         portrait,
+        permission_prompt,
         input,
         status,
     }

--- a/src/tui/layout.rs
+++ b/src/tui/layout.rs
@@ -41,9 +41,10 @@ pub fn compute_layout(
     focus_mode: bool,
     input_len: usize,
 ) -> TuiLayout {
-    // Compute input height based on text length — grows as user types
-    // +2 for "> " prefix, +2 for borders (top + bottom)
-    let text_cols = area.width.saturating_sub(2); // available width inside borders
+    // Compute input height based on text length — grows as user types.
+    // No left/right borders, so inner width = area width.
+    // +2 for "> " prefix, +2 for borders (top + bottom).
+    let text_cols = area.width; // no left/right borders
     let text_with_prefix = input_len as u16 + 2; // "> " prefix
     let text_lines = if text_cols == 0 {
         1

--- a/src/tui/markdown.rs
+++ b/src/tui/markdown.rs
@@ -1,0 +1,367 @@
+//! Minimal markdown renderer for the TUI.
+//!
+//! Line-by-line state machine that produces styled `ratatui::text::Line`s.
+//! Handles: fenced code blocks, headers, bullet lists, inline bold, inline
+//! code. No external crate — just string parsing.
+//!
+//! Panic-safe: `render_markdown_safe` catches panics and falls back to plain
+//! text. Fast-path: `needs_markdown` scans for markup characters and skips
+//! the renderer for pure prose.
+
+use std::panic::AssertUnwindSafe;
+
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+
+/// Render markdown text into styled ratatui lines, with panic safety.
+///
+/// If the renderer panics (malformed input, edge cases), falls back to
+/// plain text rendering. Pattern from srg-claude-code-rust.
+pub fn render_markdown_safe(text: &str) -> Vec<Line<'static>> {
+    if !needs_markdown(text) {
+        return plain_text(text);
+    }
+    std::panic::catch_unwind(AssertUnwindSafe(|| render_markdown(text)))
+        .unwrap_or_else(|_| plain_text(text))
+}
+
+/// Quick byte scan for markdown characters.
+///
+/// Returns false for ~40% of assistant responses that are pure prose.
+/// Pattern from pi_agent_rust's streaming_needs_markdown_renderer.
+fn needs_markdown(text: &str) -> bool {
+    for b in text.bytes() {
+        match b {
+            b'`' | b'*' | b'#' | b'-' | b'>' | b'|' | b'~' | b'[' | b']' => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Plain text fallback — one Line per text line, no styling.
+fn plain_text(text: &str) -> Vec<Line<'static>> {
+    text.lines()
+        .map(|l| Line::from(Span::raw(l.to_string())))
+        .collect()
+}
+
+/// Parser state for the line-by-line state machine.
+enum State {
+    Normal,
+    InCodeBlock { _lang: String },
+}
+
+/// Render markdown text into styled ratatui lines.
+fn render_markdown(text: &str) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut state = State::Normal;
+
+    for line in text.lines() {
+        match &state {
+            State::InCodeBlock { .. } => {
+                if line.starts_with("```") {
+                    // End code block
+                    lines.push(Line::from(Span::styled(
+                        "└───",
+                        Style::default().fg(Color::DarkGray),
+                    )));
+                    state = State::Normal;
+                } else {
+                    // Code line
+                    lines.push(Line::from(Span::styled(
+                        format!("│ {line}"),
+                        Style::default().fg(Color::Cyan),
+                    )));
+                }
+            }
+            State::Normal => {
+                // Fenced code block start
+                if line.starts_with("```") {
+                    let lang = line.trim_start_matches('`').trim().to_string();
+                    let header = if lang.is_empty() {
+                        "┌───".to_string()
+                    } else {
+                        format!("┌─── {lang} ")
+                    };
+                    lines.push(Line::from(Span::styled(
+                        header,
+                        Style::default().fg(Color::DarkGray),
+                    )));
+                    state = State::InCodeBlock { _lang: lang };
+                    continue;
+                }
+
+                // Headers
+                if let Some(rest) = line.strip_prefix("### ") {
+                    lines.push(Line::from(Span::styled(
+                        rest.to_string(),
+                        Style::default()
+                            .fg(Color::White)
+                            .add_modifier(Modifier::BOLD),
+                    )));
+                    continue;
+                }
+                if let Some(rest) = line.strip_prefix("## ") {
+                    lines.push(Line::from(Span::styled(
+                        rest.to_string(),
+                        Style::default()
+                            .fg(Color::White)
+                            .add_modifier(Modifier::BOLD),
+                    )));
+                    continue;
+                }
+                if let Some(rest) = line.strip_prefix("# ") {
+                    lines.push(Line::from(Span::styled(
+                        rest.to_string(),
+                        Style::default()
+                            .fg(Color::White)
+                            .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+                    )));
+                    continue;
+                }
+
+                // Bullet lists
+                if let Some(rest) = line.strip_prefix("- ").or_else(|| line.strip_prefix("* ")) {
+                    let mut spans =
+                        vec![Span::styled("  • ", Style::default().fg(Color::DarkGray))];
+                    spans.extend(render_inline(rest));
+                    lines.push(Line::from(spans));
+                    continue;
+                }
+
+                // Numbered lists
+                if line.chars().take_while(char::is_ascii_digit).count() > 0 {
+                    if let Some(rest) = line
+                        .find(". ")
+                        .and_then(|i| if i <= 3 { Some(&line[i + 2..]) } else { None })
+                    {
+                        let num = &line[..line.find(". ").expect("just found it")];
+                        let mut spans = vec![Span::styled(
+                            format!("  {num}. "),
+                            Style::default().fg(Color::DarkGray),
+                        )];
+                        spans.extend(render_inline(rest));
+                        lines.push(Line::from(spans));
+                        continue;
+                    }
+                }
+
+                // Blockquotes
+                if let Some(rest) = line.strip_prefix("> ") {
+                    let mut spans = vec![Span::styled("▎ ", Style::default().fg(Color::DarkGray))];
+                    spans.extend(render_inline(rest));
+                    lines.push(Line::from(spans));
+                    continue;
+                }
+
+                // Horizontal rule
+                if line.chars().all(|c| c == '-' || c == ' ') && line.contains("---") {
+                    lines.push(Line::from(Span::styled(
+                        "─".repeat(40),
+                        Style::default().fg(Color::DarkGray),
+                    )));
+                    continue;
+                }
+
+                // Normal text with inline formatting
+                lines.push(Line::from(render_inline(line)));
+            }
+        }
+    }
+
+    lines
+}
+
+/// Render inline formatting within a line: **bold**, `code`, *italic*.
+fn render_inline(text: &str) -> Vec<Span<'static>> {
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut remaining = text;
+
+    while !remaining.is_empty() {
+        // Inline code: `...`
+        if let Some(start) = remaining.find('`') {
+            if let Some(end) = remaining[start + 1..].find('`') {
+                // Push text before the code
+                if start > 0 {
+                    spans.extend(render_emphasis(&remaining[..start]));
+                }
+                // Push the code span
+                let code = &remaining[start + 1..start + 1 + end];
+                spans.push(Span::styled(
+                    code.to_string(),
+                    Style::default().fg(Color::Yellow),
+                ));
+                remaining = &remaining[start + 1 + end + 1..];
+                continue;
+            }
+        }
+
+        // No more inline code — render rest with emphasis
+        spans.extend(render_emphasis(remaining));
+        break;
+    }
+
+    if spans.is_empty() {
+        spans.push(Span::raw(String::new()));
+    }
+    spans
+}
+
+/// Render bold (**...**) and italic (*...*) within text.
+fn render_emphasis(text: &str) -> Vec<Span<'static>> {
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut remaining = text;
+
+    while !remaining.is_empty() {
+        // Bold: **...**
+        if let Some(start) = remaining.find("**") {
+            if let Some(end) = remaining[start + 2..].find("**") {
+                if start > 0 {
+                    spans.push(Span::raw(remaining[..start].to_string()));
+                }
+                let bold_text = &remaining[start + 2..start + 2 + end];
+                spans.push(Span::styled(
+                    bold_text.to_string(),
+                    Style::default().add_modifier(Modifier::BOLD),
+                ));
+                remaining = &remaining[start + 2 + end + 2..];
+                continue;
+            }
+        }
+
+        // Single *italic* (only if not **)
+        if let Some(start) = remaining.find('*') {
+            // Make sure it's not the start of **
+            if !remaining[start..].starts_with("**") {
+                if let Some(end) = remaining[start + 1..].find('*') {
+                    if !remaining[start + 1 + end..].starts_with("**") {
+                        if start > 0 {
+                            spans.push(Span::raw(remaining[..start].to_string()));
+                        }
+                        let italic_text = &remaining[start + 1..start + 1 + end];
+                        spans.push(Span::styled(
+                            italic_text.to_string(),
+                            Style::default().add_modifier(Modifier::ITALIC),
+                        ));
+                        remaining = &remaining[start + 1 + end + 1..];
+                        continue;
+                    }
+                }
+            }
+        }
+
+        // No more emphasis — push remaining as plain text
+        spans.push(Span::raw(remaining.to_string()));
+        break;
+    }
+
+    spans
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_text_passthrough() {
+        let lines = render_markdown_safe("hello world");
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].to_string(), "hello world");
+    }
+
+    #[test]
+    fn needs_markdown_detects_backtick() {
+        assert!(needs_markdown("use `foo`"));
+        assert!(!needs_markdown("plain text only"));
+    }
+
+    #[test]
+    fn header_rendering() {
+        let lines = render_markdown("# Title");
+        assert_eq!(lines.len(), 1);
+        let text = lines[0].to_string();
+        assert_eq!(text, "Title");
+    }
+
+    #[test]
+    fn h2_h3_rendering() {
+        let lines = render_markdown("## Subtitle\n### Section");
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].to_string(), "Subtitle");
+        assert_eq!(lines[1].to_string(), "Section");
+    }
+
+    #[test]
+    fn code_block_rendering() {
+        let text = "```rust\nfn main() {}\n```";
+        let lines = render_markdown(text);
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].to_string().contains("rust"));
+        assert!(lines[1].to_string().contains("fn main"));
+    }
+
+    #[test]
+    fn bullet_list() {
+        let lines = render_markdown("- item one\n- item two");
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].to_string().contains("•"));
+        assert!(lines[0].to_string().contains("item one"));
+    }
+
+    #[test]
+    fn inline_code() {
+        let lines = render_markdown("use `foo` here");
+        let text = lines[0].to_string();
+        assert!(text.contains("foo"));
+    }
+
+    #[test]
+    fn inline_bold() {
+        let lines = render_markdown("this is **bold** text");
+        let text = lines[0].to_string();
+        assert!(text.contains("bold"));
+    }
+
+    #[test]
+    fn blockquote() {
+        let lines = render_markdown("> quoted text");
+        let text = lines[0].to_string();
+        assert!(text.contains("quoted text"));
+    }
+
+    #[test]
+    fn horizontal_rule() {
+        let lines = render_markdown("---");
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].to_string().contains("─"));
+    }
+
+    #[test]
+    fn numbered_list() {
+        let lines = render_markdown("1. first\n2. second");
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].to_string().contains("1."));
+        assert!(lines[0].to_string().contains("first"));
+    }
+
+    #[test]
+    fn panic_safe_fallback() {
+        // Even with weird input, should not panic
+        let result = render_markdown_safe("```\n```\n```\n```");
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn empty_string() {
+        let lines = render_markdown_safe("");
+        assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn mixed_content() {
+        let text = "# Header\n\nSome **bold** and `code`.\n\n- item\n\n```\ncode block\n```";
+        let lines = render_markdown(text);
+        assert!(lines.len() >= 6);
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -5,6 +5,7 @@
 //! bridge — the bridge is shared infrastructure at `src/` level.
 
 pub mod app;
+pub mod diff;
 pub mod input;
 pub mod layout;
 pub mod portrait_widget;
@@ -192,6 +193,7 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                             InputAction::SlashCommand(SlashCmd::Unknown(cmd)) => {
                                 state.status_message = Some(format!("Unknown command: {cmd}"));
                             }
+                            InputAction::ToggleExpand => state.toggle_last_tool_expand(),
                             InputAction::PageUp => state.scroll.page_up(),
                             InputAction::PageDown => state.scroll.page_down(),
                             InputAction::ScrollEnd => state.scroll.scroll_to_bottom(),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -215,6 +215,21 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                                     }
                                 }
                             }
+                            InputAction::SlashCommand(SlashCmd::PortraitToggle(on)) => {
+                                state.portrait_visible = on;
+                                state.set_status(format!(
+                                    "Portrait {}",
+                                    if on { "on" } else { "off" }
+                                ));
+                            }
+                            InputAction::SlashCommand(SlashCmd::PortraitMove(pos)) => {
+                                state.portrait_position = match pos.as_str() {
+                                    "top" => app::PortraitPosition::TopRight,
+                                    "bottom" => app::PortraitPosition::BottomRight,
+                                    _ => state.portrait_position,
+                                };
+                                state.set_status(format!("Portrait: {pos}"));
+                            }
                             InputAction::SlashCommand(SlashCmd::Unknown(cmd)) => {
                                 // Forward unknown / commands to Claude Code — they
                                 // may be valid MCP/skill commands from system/init
@@ -269,13 +284,15 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                 state.frame_count += 1;
                 state.tick_status_timeout();
 
-                let has_portrait = portrait_widget.as_ref().is_some_and(portrait_widget::PortraitWidget::has_image);
+                let has_portrait = state.portrait_visible
+                    && portrait_widget.as_ref().is_some_and(portrait_widget::PortraitWidget::has_image);
                 let has_perm_prompt = state.pending_permission.is_some();
 
                 terminal.draw(|frame| {
                     let tui_layout = compute_layout(
                         frame.area(),
                         state.portrait_size,
+                        state.portrait_position,
                         has_portrait,
                         has_perm_prompt,
                     );

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -186,8 +186,14 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                             InputAction::SlashCommand(SlashCmd::Help) => {
                                 let help_text = [
                                     "Commands: /exit /clear /cost /help /login /compact /model /persona",
-                                    "Keys: Ctrl+C quit, Ctrl+O expand tool, Shift+Tab permission mode",
-                                    "      PageUp/PageDown scroll, Up/Down history, Tab complete",
+                                    "Portrait: /persona portrait [on|off|top|bottom|size <s>]",
+                                    "",
+                                    "Keys:",
+                                    "  Ctrl+C quit         Ctrl+O expand tool   Shift+Tab permission mode",
+                                    "  Ctrl+A/E home/end   Ctrl+W del word      Ctrl+U clear line",
+                                    "  Ctrl+P portrait pos Alt+P portrait on/off Alt+S portrait size",
+                                    "  Alt+T thinking      PageUp/PageDown scroll",
+                                    "  Up/Down history     Tab complete          Mouse wheel scroll",
                                 ].join("\n");
                                 state.items.push(app::ConversationItem::SystemNotice { text: help_text });
                             }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,0 +1,175 @@
+//! TUI module — ratatui-based terminal interface for aclaude.
+//!
+//! Wraps Claude Code as a headless subprocess and renders a custom TUI
+//! around the NDJSON event stream. This is one consumer of the session
+//! bridge — the bridge is shared infrastructure at `src/` level.
+
+pub mod app;
+pub mod input;
+pub mod layout;
+pub mod portrait_widget;
+pub mod scroll;
+
+use std::io;
+
+use crossterm::event::{self, Event, KeyEventKind};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use tokio::time::{Duration, interval};
+
+use self::app::{AppState, PortraitSize};
+use self::input::{InputAction, SlashCmd, handle_key};
+use self::layout::compute_layout;
+use self::portrait_widget::PortraitWidget;
+use crate::bridge;
+use crate::config::AclaudeConfig;
+use crate::error::Result;
+use crate::persona;
+use crate::portrait;
+
+/// Run the TUI prototype.
+///
+/// Sets up the terminal, spawns the Claude Code bridge subprocess,
+/// and runs the event loop until quit.
+pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
+    // Resolve portrait
+    let theme = persona::load_theme(&config.persona.theme)?;
+    let agent = persona::get_agent(&theme, &config.persona.role)?;
+    let portrait_paths =
+        portrait::resolve_portrait(&config.persona.theme, agent, Some(&config.persona.role));
+
+    // Terminal setup: raw mode FIRST, then picker query, then terminal
+    enable_raw_mode().map_err(|e| crate::error::AclaudeError::Session {
+        message: format!("failed to enable raw mode: {e}"),
+    })?;
+
+    // Portrait widget (queries terminal capabilities via stdio)
+    let mut portrait_widget = PortraitWidget::new();
+    if let Some(pw) = &mut portrait_widget {
+        pw.set_size(PortraitSize::Medium, &portrait_paths);
+    }
+
+    execute!(io::stdout(), EnterAlternateScreen).map_err(|e| {
+        let _ = disable_raw_mode();
+        crate::error::AclaudeError::Session {
+            message: format!("failed to enter alternate screen: {e}"),
+        }
+    })?;
+
+    let backend = CrosstermBackend::new(io::stdout());
+    let mut terminal = Terminal::new(backend).map_err(|e| {
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+        let _ = disable_raw_mode();
+        crate::error::AclaudeError::Session {
+            message: format!("failed to create terminal: {e}"),
+        }
+    })?;
+
+    // Spawn bridge subprocess
+    let mut session = bridge::Session::spawn(config).await?;
+    let metrics = session.metrics();
+
+    // App state
+    let mut state = AppState::new(metrics);
+
+    // Terminal event reader channel
+    let (term_tx, mut term_rx) = tokio::sync::mpsc::channel::<Event>(64);
+    tokio::task::spawn_blocking(move || {
+        while let Ok(ev) = event::read() {
+            if term_tx.blocking_send(ev).is_err() {
+                break;
+            }
+        }
+    });
+
+    // 20fps tick
+    let mut tick = interval(Duration::from_millis(50));
+
+    // Event loop
+    let result = loop {
+        tokio::select! {
+            // Bridge events (NDJSON from subprocess)
+            bridge_event = session.event_rx().recv() => {
+                match bridge_event {
+                    Some(event) => {
+                        state.apply_event(&event);
+                    }
+                    None => {
+                        // Subprocess exited
+                        break Ok(());
+                    }
+                }
+            }
+
+            // Terminal events (keyboard input)
+            term_event = term_rx.recv() => {
+                match term_event {
+                    Some(Event::Key(key)) if key.kind == KeyEventKind::Press => {
+                        match handle_key(key, &mut state.input_buffer) {
+                            InputAction::Quit => break Ok(()),
+                            InputAction::SendMessage(text) => {
+                                state.record_user_message(text.clone());
+                                if let Err(e) = session.send_user_message(&text).await {
+                                    state.status_message = Some(format!("Send error: {e}"));
+                                }
+                            }
+                            InputAction::SlashCommand(SlashCmd::PortraitSize(size_str)) => {
+                                if let Some(size) = PortraitSize::parse(&size_str) {
+                                    state.portrait_size = size;
+                                    if let Some(pw) = &mut portrait_widget {
+                                        pw.set_size(size, &portrait_paths);
+                                    }
+                                }
+                            }
+                            InputAction::SlashCommand(SlashCmd::Unknown(cmd)) => {
+                                state.status_message = Some(format!("Unknown command: {cmd}"));
+                            }
+                            InputAction::ScrollUp => state.scroll.scroll_up(),
+                            InputAction::ScrollDown => state.scroll.scroll_down(),
+                            InputAction::PageUp => state.scroll.page_up(),
+                            InputAction::PageDown => state.scroll.page_down(),
+                            InputAction::ScrollEnd => state.scroll.scroll_to_bottom(),
+                            InputAction::None => {}
+                        }
+                    }
+                    Some(Event::Resize(_, _)) => {
+                        // Terminal resized — next draw will pick up new size
+                    }
+                    Some(_) => {}
+                    None => break Ok(()),
+                }
+            }
+
+            // Tick — render frame
+            _ = tick.tick() => {
+                let has_portrait = portrait_widget.as_ref().is_some_and(portrait_widget::PortraitWidget::has_image);
+                terminal.draw(|frame| {
+                    let tui_layout = compute_layout(
+                        frame.area(),
+                        state.portrait_size,
+                        has_portrait,
+                    );
+
+                    app::render_conversation(frame, &mut state, tui_layout.conversation);
+                    app::render_input(frame, &state, tui_layout.input);
+                    app::render_status(frame, &state, tui_layout.status);
+
+                    if let Some(pw) = &mut portrait_widget {
+                        pw.render(frame, tui_layout.portrait);
+                    }
+                }).ok();
+            }
+        }
+    };
+
+    // Cleanup
+    session.shutdown().await;
+    let _ = execute!(io::stdout(), LeaveAlternateScreen);
+    let _ = disable_raw_mode();
+
+    result
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -11,6 +11,7 @@ pub mod portrait_widget;
 pub mod scroll;
 
 use std::io;
+use std::time::{Duration, Instant};
 
 use crossterm::event::{self, Event, KeyEventKind};
 use crossterm::execute;
@@ -19,7 +20,7 @@ use crossterm::terminal::{
 };
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
-use tokio::time::{Duration, interval};
+use tokio::time::interval;
 
 use self::app::{AppState, PortraitSize};
 use self::input::{InputAction, InputHistory, SlashCmd, handle_key};
@@ -30,11 +31,47 @@ use crate::config::AclaudeConfig;
 use crate::error::Result;
 use crate::persona;
 use crate::portrait;
+use crate::protocol_ext::BridgeEvent;
 
-/// Run the TUI prototype.
+/// Text batcher — buffers streaming text deltas for smooth rendering.
 ///
-/// Sets up the terminal, spawns the Claude Code bridge subprocess,
-/// and runs the event loop until quit.
+/// Coalesces consecutive TextDelta events and flushes on a 45ms timer
+/// or 2KB size threshold. Prevents per-token re-renders at 20fps.
+/// Pattern from pi_agent_rust's UiStreamDeltaBatcher.
+struct TextBatcher {
+    buffer: String,
+    last_flush: Instant,
+}
+
+impl TextBatcher {
+    fn new() -> Self {
+        Self {
+            buffer: String::new(),
+            last_flush: Instant::now(),
+        }
+    }
+
+    /// Push a text delta. Returns the flushed text if threshold met.
+    fn push(&mut self, text: &str) -> Option<String> {
+        self.buffer.push_str(text);
+        if self.buffer.len() >= 2048 || self.last_flush.elapsed() >= Duration::from_millis(45) {
+            self.flush()
+        } else {
+            None
+        }
+    }
+
+    /// Force flush any remaining buffer.
+    fn flush(&mut self) -> Option<String> {
+        if self.buffer.is_empty() {
+            return None;
+        }
+        self.last_flush = Instant::now();
+        Some(std::mem::take(&mut self.buffer))
+    }
+}
+
+/// Run the TUI.
 pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
     // Resolve portrait
     let theme = persona::load_theme(&config.persona.theme)?;
@@ -73,9 +110,10 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
     let mut session = bridge::Session::spawn(config).await?;
     let metrics = session.metrics();
 
-    // App state and input history
+    // App state, input history, text batcher
     let mut state = AppState::new(metrics);
     let mut history = InputHistory::new();
+    let mut text_batcher = TextBatcher::new();
 
     // Terminal event reader channel
     let (term_tx, mut term_rx) = tokio::sync::mpsc::channel::<Event>(64);
@@ -88,7 +126,7 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
     });
 
     // 20fps tick
-    let mut tick = interval(Duration::from_millis(50));
+    let mut tick = interval(std::time::Duration::from_millis(50));
 
     // Event loop
     let result = loop {
@@ -96,11 +134,24 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
             // Bridge events (NDJSON from subprocess)
             bridge_event = session.event_rx().recv() => {
                 match bridge_event {
+                    Some(BridgeEvent::TextDelta { text }) => {
+                        // Buffer text deltas — flush on threshold
+                        if let Some(flushed) = text_batcher.push(&text) {
+                            state.apply_event(&BridgeEvent::TextDelta { text: flushed });
+                        }
+                    }
                     Some(event) => {
+                        // Non-text events flush the batcher immediately
+                        if let Some(flushed) = text_batcher.flush() {
+                            state.apply_event(&BridgeEvent::TextDelta { text: flushed });
+                        }
                         state.apply_event(&event);
                     }
                     None => {
-                        // Subprocess exited
+                        // Subprocess exited — flush remaining
+                        if let Some(flushed) = text_batcher.flush() {
+                            state.apply_event(&BridgeEvent::TextDelta { text: flushed });
+                        }
                         break Ok(());
                     }
                 }
@@ -110,13 +161,19 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
             term_event = term_rx.recv() => {
                 match term_event {
                     Some(Event::Key(key)) if key.kind == KeyEventKind::Press => {
-                        match handle_key(key, &mut state.input_buffer, &mut history) {
+                        // Gate input by status — only Ready accepts typed input
+                        // (Ctrl+C and slash commands always work)
+                        let action = handle_key(key, &mut state.input_buffer, &mut history);
+                        match action {
                             InputAction::Quit => break Ok(()),
-                            InputAction::SendMessage(text) => {
+                            InputAction::SendMessage(text) if state.status.accepts_input() => {
                                 state.record_user_message(text.clone());
                                 if let Err(e) = session.send_user_message(&text).await {
                                     state.status_message = Some(format!("Send error: {e}"));
                                 }
+                            }
+                            InputAction::SendMessage(_) => {
+                                // Input not accepted in current state
                             }
                             InputAction::SlashCommand(SlashCmd::Exit) => break Ok(()),
                             InputAction::SlashCommand(SlashCmd::Login) => {
@@ -142,15 +199,22 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                         }
                     }
                     Some(Event::Resize(_, _)) => {
-                        // Terminal resized — next draw will pick up new size
+                        // Terminal resized — next draw picks up new size
                     }
                     Some(_) => {}
                     None => break Ok(()),
                 }
             }
 
-            // Tick — render frame
+            // Tick — render frame + flush batcher on timer
             _ = tick.tick() => {
+                // Flush any buffered text on tick (45ms timer threshold)
+                if let Some(flushed) = text_batcher.flush() {
+                    state.apply_event(&BridgeEvent::TextDelta { text: flushed });
+                }
+
+                state.frame_count += 1;
+
                 let has_portrait = portrait_widget.as_ref().is_some_and(portrait_widget::PortraitWidget::has_image);
                 terminal.draw(|frame| {
                     let tui_layout = compute_layout(
@@ -159,7 +223,6 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                         has_portrait,
                     );
 
-                    // Conversation first (full width), then portrait overlays on top
                     app::render_conversation(frame, &mut state, tui_layout.conversation);
                     if let Some(pw) = &mut portrait_widget {
                         pw.render(frame, tui_layout.portrait);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -190,10 +190,10 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                                     "Portrait: /persona portrait [on|off|top|bottom|size <s>]",
                                     "",
                                     "Keys:",
-                                    "  Ctrl+C quit         Ctrl+O expand tool   Shift+Tab permission mode",
-                                    "  Ctrl+A/E home/end   Ctrl+W del word      Ctrl+U clear line",
+                                    "  Ctrl+C quit         Ctrl+O transcript     Ctrl+X expand tool",
+                                    "  Ctrl+A/E home/end   Ctrl+W del word       Ctrl+U clear line",
                                     "  Ctrl+P portrait pos Alt+P portrait on/off Alt+S portrait size",
-                                    "  Alt+T thinking      PageUp/PageDown scroll",
+                                    "  Alt+T thinking      Shift+Tab perm mode   Ctrl+G editor",
                                     "  Up/Down history     Tab complete          Mouse wheel scroll",
                                 ].join("\n");
                                 state.items.push(app::ConversationItem::SystemNotice { text: help_text });
@@ -298,6 +298,36 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                                     state.portrait_size.label()
                                 ));
                             }
+                            InputAction::CycleTranscript => {
+                                let next = state.transcript_mode.next();
+                                if next == app::TranscriptMode::Transcript {
+                                    // Dump conversation to native terminal scrollback
+                                    let _ = execute!(
+                                        io::stdout(),
+                                        DisableMouseCapture,
+                                        LeaveAlternateScreen
+                                    );
+                                    let _ = disable_raw_mode();
+                                    print!("{}", state.conversation_as_text());
+                                    println!("--- Press any key to return ---");
+                                    // Wait for a key press
+                                    let _ = enable_raw_mode();
+                                    let _ = crossterm::event::read();
+                                    let _ = execute!(
+                                        io::stdout(),
+                                        EnterAlternateScreen,
+                                        EnableMouseCapture
+                                    );
+                                    // Stay in Normal after viewing transcript
+                                    state.transcript_mode = app::TranscriptMode::Normal;
+                                } else {
+                                    state.transcript_mode = next;
+                                    state.set_status(format!(
+                                        "View: {}",
+                                        next.label()
+                                    ));
+                                }
+                            }
                             InputAction::ToggleExpand => state.toggle_last_tool_expand(),
                             InputAction::ToggleThinking => {
                                 state.show_thinking = !state.show_thinking;
@@ -347,12 +377,14 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                 let has_perm_prompt = state.pending_permission.is_some();
 
                 terminal.draw(|frame| {
+                    let is_focus = state.transcript_mode == app::TranscriptMode::Focus;
                     let tui_layout = compute_layout(
                         frame.area(),
                         state.portrait_size,
                         state.portrait_position,
                         has_portrait,
                         has_perm_prompt,
+                        is_focus,
                     );
 
                     app::render_conversation(frame, &mut state, tui_layout.conversation);
@@ -365,7 +397,9 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                     }
 
                     app::render_input(frame, &state, tui_layout.input);
-                    app::render_status(frame, &state, tui_layout.status);
+                    if tui_layout.status.height > 0 {
+                        app::render_status(frame, &state, tui_layout.status);
+                    }
                 }).ok();
             }
         }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -8,6 +8,7 @@ pub mod app;
 pub mod diff;
 pub mod input;
 pub mod layout;
+pub mod markdown;
 pub mod portrait_widget;
 pub mod scroll;
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -118,6 +118,12 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                                     state.status_message = Some(format!("Send error: {e}"));
                                 }
                             }
+                            InputAction::SlashCommand(SlashCmd::Exit) => break Ok(()),
+                            InputAction::SlashCommand(SlashCmd::Login) => {
+                                state.status_message = Some(
+                                    "Auth is managed by Claude Code. Run `claude login` in a separate terminal to re-authenticate.".to_string()
+                                );
+                            }
                             InputAction::SlashCommand(SlashCmd::PortraitSize(size_str)) => {
                                 if let Some(size) = PortraitSize::parse(&size_str) {
                                     state.portrait_size = size;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -388,17 +388,26 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                 state.frame_count += 1;
                 state.tick_status_timeout();
 
-                let has_portrait = state.portrait_visible
-                    && portrait_widget.as_ref().is_some_and(portrait_widget::PortraitWidget::has_image);
                 let has_perm_prompt = state.pending_permission.is_some();
 
                 terminal.draw(|frame| {
+                    let area = frame.area();
+                    // Compute portrait cell size from actual image dimensions
+                    let portrait_cell_size = if state.portrait_visible {
+                        portrait_widget.as_ref().and_then(|pw| {
+                            let max_w = portrait_max_width(state.portrait_size, area.width);
+                            let max_h = area.height / 2;
+                            pw.cell_size(max_w, max_h)
+                        })
+                    } else {
+                        None
+                    };
+
                     let is_focus = state.transcript_mode == app::TranscriptMode::Focus;
                     let tui_layout = compute_layout(
-                        frame.area(),
-                        state.portrait_size,
+                        area,
                         state.portrait_position,
-                        has_portrait,
+                        portrait_cell_size,
                         has_perm_prompt,
                         is_focus,
                         state.input.buffer.len(),
@@ -433,4 +442,14 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
     let _ = disable_raw_mode();
 
     result
+}
+
+/// Max width in cells for a portrait size setting.
+fn portrait_max_width(size: PortraitSize, terminal_width: u16) -> u16 {
+    match size {
+        PortraitSize::Small => 20,
+        PortraitSize::Medium => 32,
+        PortraitSize::Large => 48,
+        PortraitSize::Original => (terminal_width / 3).min(64),
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -16,7 +16,8 @@ use std::io;
 use std::time::{Duration, Instant};
 
 use crossterm::event::{
-    self, DisableMouseCapture, EnableMouseCapture, Event, KeyEventKind, MouseEventKind,
+    self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+    Event, KeyEventKind, MouseEventKind,
 };
 use crossterm::execute;
 use crossterm::terminal::{
@@ -87,7 +88,13 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
         pw.set_size(PortraitSize::Medium, &portrait_paths);
     }
 
-    execute!(io::stdout(), EnterAlternateScreen, EnableMouseCapture).map_err(|e| {
+    execute!(
+        io::stdout(),
+        EnterAlternateScreen,
+        EnableMouseCapture,
+        EnableBracketedPaste
+    )
+    .map_err(|e| {
         let _ = disable_raw_mode();
         crate::error::AclaudeError::Session {
             message: format!("failed to enter alternate screen: {e}"),
@@ -304,19 +311,20 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                                     // Dump conversation to native terminal scrollback
                                     let _ = execute!(
                                         io::stdout(),
+                                        DisableBracketedPaste,
                                         DisableMouseCapture,
                                         LeaveAlternateScreen
                                     );
                                     let _ = disable_raw_mode();
                                     print!("{}", state.conversation_as_text());
                                     println!("--- Press any key to return ---");
-                                    // Wait for a key press
                                     let _ = enable_raw_mode();
                                     let _ = crossterm::event::read();
                                     let _ = execute!(
                                         io::stdout(),
                                         EnterAlternateScreen,
-                                        EnableMouseCapture
+                                        EnableMouseCapture,
+                                        EnableBracketedPaste
                                     );
                                     // Stay in Normal after viewing transcript
                                     state.transcript_mode = app::TranscriptMode::Normal;
@@ -348,6 +356,14 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                             InputAction::PageDown => state.scroll.page_down(),
                             InputAction::ScrollEnd => state.scroll.scroll_to_bottom(),
                             InputAction::None => {}
+                        }
+                    }
+                    Some(Event::Paste(text)) => {
+                        // Bracketed paste — insert pasted text at cursor
+                        for c in text.chars() {
+                            if c != '\n' && c != '\r' {
+                                state.input.insert(c);
+                            }
                         }
                     }
                     Some(Event::Mouse(mouse)) => {
@@ -385,6 +401,7 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                         has_portrait,
                         has_perm_prompt,
                         is_focus,
+                        state.input.buffer.len(),
                     );
 
                     app::render_conversation(frame, &mut state, tui_layout.conversation);
@@ -407,7 +424,12 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
 
     // Cleanup
     session.shutdown().await;
-    let _ = execute!(io::stdout(), DisableMouseCapture, LeaveAlternateScreen);
+    let _ = execute!(
+        io::stdout(),
+        DisableBracketedPaste,
+        DisableMouseCapture,
+        LeaveAlternateScreen
+    );
     let _ = disable_raw_mode();
 
     result

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -72,6 +72,21 @@ impl TextBatcher {
 
 /// Run the TUI.
 pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
+    // Install panic hook to restore terminal state on panic.
+    // Without this, a panic leaves the terminal in raw mode with
+    // alternate screen and mouse capture still active.
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(
+            io::stdout(),
+            DisableBracketedPaste,
+            DisableMouseCapture,
+            LeaveAlternateScreen
+        );
+        original_hook(info);
+    }));
+
     // Resolve portrait
     let theme = persona::load_theme(&config.persona.theme)?;
     let agent = persona::get_agent(&theme, &config.persona.role)?;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -264,6 +264,33 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                                 }
                             }
 
+                            InputAction::PortraitTogglePosition => {
+                                state.portrait_position = state.portrait_position.toggle();
+                                state.set_status(format!(
+                                    "Portrait: {}",
+                                    match state.portrait_position {
+                                        app::PortraitPosition::TopRight => "top",
+                                        app::PortraitPosition::BottomRight => "bottom",
+                                    }
+                                ));
+                            }
+                            InputAction::PortraitToggleVisible => {
+                                state.portrait_visible = !state.portrait_visible;
+                                state.set_status(format!(
+                                    "Portrait {}",
+                                    if state.portrait_visible { "on" } else { "off" }
+                                ));
+                            }
+                            InputAction::PortraitCycleSize => {
+                                state.portrait_size = state.portrait_size.next();
+                                if let Some(pw) = &mut portrait_widget {
+                                    pw.set_size(state.portrait_size, &portrait_paths);
+                                }
+                                state.set_status(format!(
+                                    "Portrait size: {}",
+                                    state.portrait_size.label()
+                                ));
+                            }
                             InputAction::ToggleExpand => state.toggle_last_tool_expand(),
                             InputAction::ToggleThinking => {
                                 state.show_thinking = !state.show_thinking;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -22,7 +22,7 @@ use ratatui::backend::CrosstermBackend;
 use tokio::time::{Duration, interval};
 
 use self::app::{AppState, PortraitSize};
-use self::input::{InputAction, SlashCmd, handle_key};
+use self::input::{InputAction, InputHistory, SlashCmd, handle_key};
 use self::layout::compute_layout;
 use self::portrait_widget::PortraitWidget;
 use crate::bridge;
@@ -73,8 +73,9 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
     let mut session = bridge::Session::spawn(config).await?;
     let metrics = session.metrics();
 
-    // App state
+    // App state and input history
     let mut state = AppState::new(metrics);
+    let mut history = InputHistory::new();
 
     // Terminal event reader channel
     let (term_tx, mut term_rx) = tokio::sync::mpsc::channel::<Event>(64);
@@ -109,7 +110,7 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
             term_event = term_rx.recv() => {
                 match term_event {
                     Some(Event::Key(key)) if key.kind == KeyEventKind::Press => {
-                        match handle_key(key, &mut state.input_buffer) {
+                        match handle_key(key, &mut state.input_buffer, &mut history) {
                             InputAction::Quit => break Ok(()),
                             InputAction::SendMessage(text) => {
                                 state.record_user_message(text.clone());
@@ -128,8 +129,6 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                             InputAction::SlashCommand(SlashCmd::Unknown(cmd)) => {
                                 state.status_message = Some(format!("Unknown command: {cmd}"));
                             }
-                            InputAction::ScrollUp => state.scroll.scroll_up(),
-                            InputAction::ScrollDown => state.scroll.scroll_down(),
                             InputAction::PageUp => state.scroll.page_up(),
                             InputAction::PageDown => state.scroll.page_down(),
                             InputAction::ScrollEnd => state.scroll.scroll_to_bottom(),
@@ -154,13 +153,14 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                         has_portrait,
                     );
 
+                    // Conversation first (full width), then portrait overlays on top
                     app::render_conversation(frame, &mut state, tui_layout.conversation);
-                    app::render_input(frame, &state, tui_layout.input);
-                    app::render_status(frame, &state, tui_layout.status);
-
                     if let Some(pw) = &mut portrait_widget {
                         pw.render(frame, tui_layout.portrait);
                     }
+
+                    app::render_input(frame, &state, tui_layout.input);
+                    app::render_status(frame, &state, tui_layout.status);
                 }).ok();
             }
         }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -14,7 +14,9 @@ pub mod scroll;
 use std::io;
 use std::time::{Duration, Instant};
 
-use crossterm::event::{self, Event, KeyEventKind};
+use crossterm::event::{
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyEventKind, MouseEventKind,
+};
 use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
@@ -84,7 +86,7 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
         pw.set_size(PortraitSize::Medium, &portrait_paths);
     }
 
-    execute!(io::stdout(), EnterAlternateScreen).map_err(|e| {
+    execute!(io::stdout(), EnterAlternateScreen, EnableMouseCapture).map_err(|e| {
         let _ = disable_raw_mode();
         crate::error::AclaudeError::Session {
             message: format!("failed to enter alternate screen: {e}"),
@@ -155,7 +157,7 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                         let has_perm = state.pending_permission.is_some();
                         let action = handle_key(
                             key,
-                            &mut state.input_buffer,
+                            &mut state.input,
                             &mut history,
                             has_perm,
                             &state.available_slash_commands,
@@ -263,10 +265,32 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                             }
 
                             InputAction::ToggleExpand => state.toggle_last_tool_expand(),
+                            InputAction::ToggleThinking => {
+                                state.show_thinking = !state.show_thinking;
+                                state.set_status(format!(
+                                    "Thinking blocks: {}",
+                                    if state.show_thinking { "shown" } else { "hidden" }
+                                ));
+                            }
+                            InputAction::OpenEditor => {
+                                // Stub — full implementation in a later pass
+                                state.set_status(
+                                    "External editor not yet implemented. Use Ctrl+U to clear input.".to_string()
+                                );
+                            }
+                            InputAction::ScrollUp => state.scroll.scroll_up(),
+                            InputAction::ScrollDown => state.scroll.scroll_down(),
                             InputAction::PageUp => state.scroll.page_up(),
                             InputAction::PageDown => state.scroll.page_down(),
                             InputAction::ScrollEnd => state.scroll.scroll_to_bottom(),
                             InputAction::None => {}
+                        }
+                    }
+                    Some(Event::Mouse(mouse)) => {
+                        match mouse.kind {
+                            MouseEventKind::ScrollUp => state.scroll.scroll_up(),
+                            MouseEventKind::ScrollDown => state.scroll.scroll_down(),
+                            _ => {}
                         }
                     }
                     Some(Event::Resize(_, _)) => {}
@@ -315,7 +339,7 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
 
     // Cleanup
     session.shutdown().await;
-    let _ = execute!(io::stdout(), LeaveAlternateScreen);
+    let _ = execute!(io::stdout(), DisableMouseCapture, LeaveAlternateScreen);
     let _ = disable_raw_mode();
 
     result

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -153,23 +153,59 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                 match term_event {
                     Some(Event::Key(key)) if key.kind == KeyEventKind::Press => {
                         let has_perm = state.pending_permission.is_some();
-                        let action = handle_key(key, &mut state.input_buffer, &mut history, has_perm);
+                        let action = handle_key(
+                            key,
+                            &mut state.input_buffer,
+                            &mut history,
+                            has_perm,
+                            &state.available_slash_commands,
+                        );
                         match action {
                             InputAction::Quit => break Ok(()),
 
                             InputAction::SendMessage(text) if state.status.accepts_input() => {
                                 state.record_user_message(text.clone());
                                 if let Err(e) = session.send_user_message(&text).await {
-                                    state.status_message = Some(format!("Send error: {e}"));
+                                    state.set_status(format!("Send error: {e}"));
                                 }
                             }
                             InputAction::SendMessage(_) => {}
 
                             InputAction::SlashCommand(SlashCmd::Exit) => break Ok(()),
                             InputAction::SlashCommand(SlashCmd::Login) => {
-                                state.status_message = Some(
+                                state.set_status(
                                     "Auth is managed by Claude Code. Run `claude login` in a separate terminal.".to_string()
                                 );
+                            }
+                            InputAction::SlashCommand(SlashCmd::Clear) => {
+                                state.items.clear();
+                                state.set_status("Conversation cleared".to_string());
+                            }
+                            InputAction::SlashCommand(SlashCmd::Help) => {
+                                let help_text = [
+                                    "Commands: /exit /clear /cost /help /login /compact /model /persona",
+                                    "Keys: Ctrl+C quit, Ctrl+O expand tool, Shift+Tab permission mode",
+                                    "      PageUp/PageDown scroll, Up/Down history, Tab complete",
+                                ].join("\n");
+                                state.items.push(app::ConversationItem::SystemNotice { text: help_text });
+                            }
+                            InputAction::SlashCommand(SlashCmd::Cost) => {
+                                let msg = {
+                                    let m = state.metrics.lock()
+                                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                                    format!(
+                                        "Cost: ${:.4} | Turns: {} | Tokens: {}↓ {}↑",
+                                        m.cost_usd, m.num_turns, m.input_tokens, m.output_tokens
+                                    )
+                                };
+                                state.set_status(msg);
+                            }
+                            InputAction::SlashCommand(SlashCmd::ForwardToAgent(cmd)) => {
+                                // Forward Claude Code slash commands as user messages
+                                state.record_user_message(cmd.clone());
+                                if let Err(e) = session.send_user_message(&cmd).await {
+                                    state.set_status(format!("Send error: {e}"));
+                                }
                             }
                             InputAction::SlashCommand(SlashCmd::PortraitSize(size_str)) => {
                                 if let Some(size) = PortraitSize::parse(&size_str) {
@@ -180,12 +216,17 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                                 }
                             }
                             InputAction::SlashCommand(SlashCmd::Unknown(cmd)) => {
-                                state.status_message = Some(format!("Unknown command: {cmd}"));
+                                // Forward unknown / commands to Claude Code — they
+                                // may be valid MCP/skill commands from system/init
+                                state.record_user_message(cmd.clone());
+                                if let Err(e) = session.send_user_message(&cmd).await {
+                                    state.set_status(format!("Send error: {e}"));
+                                }
                             }
 
                             InputAction::CyclePermissionMode => {
                                 state.permission_mode = state.permission_mode.next();
-                                state.status_message = Some(format!(
+                                state.set_status(format!(
                                     "Permission mode: {}",
                                     state.permission_mode.label()
                                 ));
@@ -193,16 +234,16 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
 
                             InputAction::PermissionAllow => {
                                 state.pending_permission = None;
-                                state.status_message = Some("Permission: allowed".to_string());
+                                state.set_status("Permission: allowed".to_string());
                                 if let Err(e) = session.send_permission_response(true).await {
-                                    state.status_message = Some(format!("Send error: {e}"));
+                                    state.set_status(format!("Send error: {e}"));
                                 }
                             }
                             InputAction::PermissionDeny => {
                                 state.pending_permission = None;
-                                state.status_message = Some("Permission: denied".to_string());
+                                state.set_status("Permission: denied".to_string());
                                 if let Err(e) = session.send_permission_response(false).await {
-                                    state.status_message = Some(format!("Send error: {e}"));
+                                    state.set_status(format!("Send error: {e}"));
                                 }
                             }
 
@@ -226,6 +267,7 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                 }
 
                 state.frame_count += 1;
+                state.tick_status_timeout();
 
                 let has_portrait = portrait_widget.as_ref().is_some_and(portrait_widget::PortraitWidget::has_image);
                 let has_perm_prompt = state.pending_permission.is_some();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -35,10 +35,6 @@ use crate::portrait;
 use crate::protocol_ext::BridgeEvent;
 
 /// Text batcher — buffers streaming text deltas for smooth rendering.
-///
-/// Coalesces consecutive TextDelta events and flushes on a 45ms timer
-/// or 2KB size threshold. Prevents per-token re-renders at 20fps.
-/// Pattern from pi_agent_rust's UiStreamDeltaBatcher.
 struct TextBatcher {
     buffer: String,
     last_flush: Instant,
@@ -52,7 +48,6 @@ impl TextBatcher {
         }
     }
 
-    /// Push a text delta. Returns the flushed text if threshold met.
     fn push(&mut self, text: &str) -> Option<String> {
         self.buffer.push_str(text);
         if self.buffer.len() >= 2048 || self.last_flush.elapsed() >= Duration::from_millis(45) {
@@ -62,7 +57,6 @@ impl TextBatcher {
         }
     }
 
-    /// Force flush any remaining buffer.
     fn flush(&mut self) -> Option<String> {
         if self.buffer.is_empty() {
             return None;
@@ -85,7 +79,6 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
         message: format!("failed to enable raw mode: {e}"),
     })?;
 
-    // Portrait widget (queries terminal capabilities via stdio)
     let mut portrait_widget = PortraitWidget::new();
     if let Some(pw) = &mut portrait_widget {
         pw.set_size(PortraitSize::Medium, &portrait_paths);
@@ -132,24 +125,21 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
     // Event loop
     let result = loop {
         tokio::select! {
-            // Bridge events (NDJSON from subprocess)
+            // Bridge events
             bridge_event = session.event_rx().recv() => {
                 match bridge_event {
                     Some(BridgeEvent::TextDelta { text }) => {
-                        // Buffer text deltas — flush on threshold
                         if let Some(flushed) = text_batcher.push(&text) {
                             state.apply_event(&BridgeEvent::TextDelta { text: flushed });
                         }
                     }
                     Some(event) => {
-                        // Non-text events flush the batcher immediately
                         if let Some(flushed) = text_batcher.flush() {
                             state.apply_event(&BridgeEvent::TextDelta { text: flushed });
                         }
                         state.apply_event(&event);
                     }
                     None => {
-                        // Subprocess exited — flush remaining
                         if let Some(flushed) = text_batcher.flush() {
                             state.apply_event(&BridgeEvent::TextDelta { text: flushed });
                         }
@@ -158,28 +148,27 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                 }
             }
 
-            // Terminal events (keyboard input)
+            // Terminal events
             term_event = term_rx.recv() => {
                 match term_event {
                     Some(Event::Key(key)) if key.kind == KeyEventKind::Press => {
-                        // Gate input by status — only Ready accepts typed input
-                        // (Ctrl+C and slash commands always work)
-                        let action = handle_key(key, &mut state.input_buffer, &mut history);
+                        let has_perm = state.pending_permission.is_some();
+                        let action = handle_key(key, &mut state.input_buffer, &mut history, has_perm);
                         match action {
                             InputAction::Quit => break Ok(()),
+
                             InputAction::SendMessage(text) if state.status.accepts_input() => {
                                 state.record_user_message(text.clone());
                                 if let Err(e) = session.send_user_message(&text).await {
                                     state.status_message = Some(format!("Send error: {e}"));
                                 }
                             }
-                            InputAction::SendMessage(_) => {
-                                // Input not accepted in current state
-                            }
+                            InputAction::SendMessage(_) => {}
+
                             InputAction::SlashCommand(SlashCmd::Exit) => break Ok(()),
                             InputAction::SlashCommand(SlashCmd::Login) => {
                                 state.status_message = Some(
-                                    "Auth is managed by Claude Code. Run `claude login` in a separate terminal to re-authenticate.".to_string()
+                                    "Auth is managed by Claude Code. Run `claude login` in a separate terminal.".to_string()
                                 );
                             }
                             InputAction::SlashCommand(SlashCmd::PortraitSize(size_str)) => {
@@ -193,6 +182,30 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                             InputAction::SlashCommand(SlashCmd::Unknown(cmd)) => {
                                 state.status_message = Some(format!("Unknown command: {cmd}"));
                             }
+
+                            InputAction::CyclePermissionMode => {
+                                state.permission_mode = state.permission_mode.next();
+                                state.status_message = Some(format!(
+                                    "Permission mode: {}",
+                                    state.permission_mode.label()
+                                ));
+                            }
+
+                            InputAction::PermissionAllow => {
+                                state.pending_permission = None;
+                                state.status_message = Some("Permission: allowed".to_string());
+                                if let Err(e) = session.send_permission_response(true).await {
+                                    state.status_message = Some(format!("Send error: {e}"));
+                                }
+                            }
+                            InputAction::PermissionDeny => {
+                                state.pending_permission = None;
+                                state.status_message = Some("Permission: denied".to_string());
+                                if let Err(e) = session.send_permission_response(false).await {
+                                    state.status_message = Some(format!("Send error: {e}"));
+                                }
+                            }
+
                             InputAction::ToggleExpand => state.toggle_last_tool_expand(),
                             InputAction::PageUp => state.scroll.page_up(),
                             InputAction::PageDown => state.scroll.page_down(),
@@ -200,17 +213,14 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                             InputAction::None => {}
                         }
                     }
-                    Some(Event::Resize(_, _)) => {
-                        // Terminal resized — next draw picks up new size
-                    }
+                    Some(Event::Resize(_, _)) => {}
                     Some(_) => {}
                     None => break Ok(()),
                 }
             }
 
-            // Tick — render frame + flush batcher on timer
+            // Tick — render frame
             _ = tick.tick() => {
-                // Flush any buffered text on tick (45ms timer threshold)
                 if let Some(flushed) = text_batcher.flush() {
                     state.apply_event(&BridgeEvent::TextDelta { text: flushed });
                 }
@@ -218,16 +228,23 @@ pub async fn run_tui(config: &AclaudeConfig) -> Result<()> {
                 state.frame_count += 1;
 
                 let has_portrait = portrait_widget.as_ref().is_some_and(portrait_widget::PortraitWidget::has_image);
+                let has_perm_prompt = state.pending_permission.is_some();
+
                 terminal.draw(|frame| {
                     let tui_layout = compute_layout(
                         frame.area(),
                         state.portrait_size,
                         has_portrait,
+                        has_perm_prompt,
                     );
 
                     app::render_conversation(frame, &mut state, tui_layout.conversation);
                     if let Some(pw) = &mut portrait_widget {
                         pw.render(frame, tui_layout.portrait);
+                    }
+
+                    if let Some(prompt) = &state.pending_permission {
+                        app::render_permission_prompt(frame, prompt, tui_layout.permission_prompt);
                     }
 
                     app::render_input(frame, &state, tui_layout.input);

--- a/src/tui/portrait_widget.rs
+++ b/src/tui/portrait_widget.rs
@@ -1,0 +1,93 @@
+//! Portrait image overlay widget for ratatui.
+//!
+//! Wraps `ratatui-image` to render persona portraits in the TUI.
+//! Falls back gracefully when the terminal doesn't support inline images.
+
+use std::path::{Path, PathBuf};
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui_image::picker::Picker;
+use ratatui_image::protocol::StatefulProtocol;
+use ratatui_image::{Resize, StatefulImage};
+
+use super::app::PortraitSize;
+use crate::portrait::PortraitPaths;
+
+/// Portrait widget state.
+///
+/// Manages the image picker, current protocol state, and loaded image path.
+/// Returns `None` from `new()` if the terminal doesn't support images.
+pub struct PortraitWidget {
+    picker: Picker,
+    image_state: Option<StatefulProtocol>,
+    current_path: Option<PathBuf>,
+}
+
+impl PortraitWidget {
+    /// Create a new portrait widget.
+    ///
+    /// Must be called AFTER `crossterm::terminal::enable_raw_mode()` and
+    /// BEFORE `Terminal::new()` — the picker queries terminal capabilities
+    /// via stdio.
+    ///
+    /// Returns `None` if the terminal doesn't support inline images.
+    pub fn new() -> Option<Self> {
+        let picker = Picker::from_query_stdio().ok()?;
+        Some(Self {
+            picker,
+            image_state: None,
+            current_path: None,
+        })
+    }
+
+    /// Set the portrait size, loading the appropriate image.
+    ///
+    /// Only reloads if the resolved path changed.
+    pub fn set_size(&mut self, size: PortraitSize, paths: &PortraitPaths) {
+        let size_str = match size {
+            PortraitSize::Small => "small",
+            PortraitSize::Medium => "medium",
+            PortraitSize::Large => "large",
+            PortraitSize::Original => "original",
+        };
+        let target_path = paths.best_for_size(size_str).map(Path::to_path_buf);
+
+        // Skip reload if same path
+        if self.current_path == target_path {
+            return;
+        }
+
+        self.current_path = target_path.clone();
+
+        if let Some(path) = target_path {
+            match image::open(&path) {
+                Ok(img) => {
+                    let protocol = self.picker.new_resize_protocol(img);
+                    self.image_state = Some(protocol);
+                }
+                Err(_) => {
+                    self.image_state = None;
+                }
+            }
+        } else {
+            self.image_state = None;
+        }
+    }
+
+    /// Whether a portrait image is loaded and ready to render.
+    pub fn has_image(&self) -> bool {
+        self.image_state.is_some()
+    }
+
+    /// Render the portrait in the given area.
+    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        if let Some(state) = &mut self.image_state {
+            let image = StatefulImage::default().resize(Resize::Fit(None));
+            frame.render_stateful_widget(image, area, state);
+        }
+    }
+}

--- a/src/tui/portrait_widget.rs
+++ b/src/tui/portrait_widget.rs
@@ -87,9 +87,11 @@ impl PortraitWidget {
             return None;
         }
 
-        // Image size in cells at native resolution
-        let native_cols = (px_w as u16).div_ceil(font.0);
-        let native_rows = (px_h as u16).div_ceil(font.1);
+        // Image size in cells at native resolution (cap to prevent u16 overflow)
+        let capped_w = px_w.min(u16::MAX as u32) as u16;
+        let capped_h = px_h.min(u16::MAX as u32) as u16;
+        let native_cols = capped_w.div_ceil(font.0);
+        let native_rows = capped_h.div_ceil(font.1);
 
         if native_cols == 0 || native_rows == 0 {
             return None;

--- a/src/tui/portrait_widget.rs
+++ b/src/tui/portrait_widget.rs
@@ -15,35 +15,30 @@ use super::app::PortraitSize;
 use crate::portrait::PortraitPaths;
 
 /// Portrait widget state.
-///
-/// Manages the image picker, current protocol state, and loaded image path.
-/// Returns `None` from `new()` if the terminal doesn't support images.
 pub struct PortraitWidget {
     picker: Picker,
     image_state: Option<StatefulProtocol>,
     current_path: Option<PathBuf>,
+    /// Image dimensions in pixels (width, height).
+    image_pixels: Option<(u32, u32)>,
 }
 
 impl PortraitWidget {
     /// Create a new portrait widget.
     ///
     /// Must be called AFTER `crossterm::terminal::enable_raw_mode()` and
-    /// BEFORE `Terminal::new()` — the picker queries terminal capabilities
-    /// via stdio.
-    ///
-    /// Returns `None` if the terminal doesn't support inline images.
+    /// BEFORE `Terminal::new()`.
     pub fn new() -> Option<Self> {
         let picker = Picker::from_query_stdio().ok()?;
         Some(Self {
             picker,
             image_state: None,
             current_path: None,
+            image_pixels: None,
         })
     }
 
     /// Set the portrait size, loading the appropriate image.
-    ///
-    /// Only reloads if the resolved path changed.
     pub fn set_size(&mut self, size: PortraitSize, paths: &PortraitPaths) {
         let size_str = match size {
             PortraitSize::Small => "small",
@@ -53,16 +48,17 @@ impl PortraitWidget {
         };
         let target_path = paths.best_for_size(size_str).map(Path::to_path_buf);
 
-        // Skip reload if same path
         if self.current_path == target_path {
             return;
         }
 
         self.current_path = target_path.clone();
+        self.image_pixels = None;
 
         if let Some(path) = target_path {
             match image::open(&path) {
                 Ok(img) => {
+                    self.image_pixels = Some((img.width(), img.height()));
                     let protocol = self.picker.new_resize_protocol(img);
                     self.image_state = Some(protocol);
                 }
@@ -78,6 +74,36 @@ impl PortraitWidget {
     /// Whether a portrait image is loaded and ready to render.
     pub fn has_image(&self) -> bool {
         self.image_state.is_some()
+    }
+
+    /// Get the image dimensions in terminal cells for the given max width.
+    ///
+    /// Uses the picker's font size to convert pixel dimensions to cell
+    /// dimensions. Returns (cols, rows) clamped to max_width.
+    pub fn cell_size(&self, max_width: u16, max_height: u16) -> Option<(u16, u16)> {
+        let (px_w, px_h) = self.image_pixels?;
+        let font = self.picker.font_size();
+        if font.0 == 0 || font.1 == 0 {
+            return None;
+        }
+
+        // Image size in cells at native resolution
+        let native_cols = (px_w as u16).div_ceil(font.0);
+        let native_rows = (px_h as u16).div_ceil(font.1);
+
+        if native_cols == 0 || native_rows == 0 {
+            return None;
+        }
+
+        // Scale to fit within max_width, preserving aspect ratio
+        let scale_w = max_width as f64 / native_cols as f64;
+        let scale_h = max_height as f64 / native_rows as f64;
+        let scale = scale_w.min(scale_h).min(1.0); // never upscale
+
+        let cols = (native_cols as f64 * scale).ceil() as u16;
+        let rows = (native_rows as f64 * scale).ceil() as u16;
+
+        Some((cols.max(1), rows.max(1)))
     }
 
     /// Render the portrait in the given area.

--- a/src/tui/scroll.rs
+++ b/src/tui/scroll.rs
@@ -1,0 +1,144 @@
+//! Scroll state for the conversation viewport.
+
+/// Tracks scroll position with auto-scroll behavior.
+///
+/// Auto-scroll follows new content as it arrives. Manual scrolling
+/// (arrow keys, page up) disables auto-scroll. End key re-enables it.
+#[derive(Debug)]
+pub struct ScrollState {
+    /// Current scroll offset (lines from top).
+    pub offset: u16,
+    /// Total content height in lines.
+    pub content_height: u16,
+    /// Visible viewport height in lines.
+    pub viewport_height: u16,
+    /// Whether to automatically follow new content.
+    pub auto_scroll: bool,
+}
+
+impl Default for ScrollState {
+    fn default() -> Self {
+        Self {
+            offset: 0,
+            content_height: 0,
+            viewport_height: 0,
+            auto_scroll: true,
+        }
+    }
+}
+
+impl ScrollState {
+    /// Maximum valid scroll offset.
+    fn max_offset(&self) -> u16 {
+        self.content_height.saturating_sub(self.viewport_height)
+    }
+
+    /// Update content height and auto-scroll to bottom if enabled.
+    pub fn set_content_height(&mut self, height: u16) {
+        self.content_height = height;
+        if self.auto_scroll {
+            self.offset = self.max_offset();
+        }
+    }
+
+    /// Update viewport height.
+    pub fn set_viewport_height(&mut self, height: u16) {
+        self.viewport_height = height;
+        if self.auto_scroll {
+            self.offset = self.max_offset();
+        }
+    }
+
+    /// Scroll up by one line. Disables auto-scroll.
+    pub fn scroll_up(&mut self) {
+        self.auto_scroll = false;
+        self.offset = self.offset.saturating_sub(1);
+    }
+
+    /// Scroll down by one line.
+    pub fn scroll_down(&mut self) {
+        self.auto_scroll = false;
+        let max = self.max_offset();
+        self.offset = (self.offset + 1).min(max);
+        // Re-enable auto-scroll if we've scrolled to bottom
+        if self.offset >= max {
+            self.auto_scroll = true;
+        }
+    }
+
+    /// Scroll up by a page.
+    pub fn page_up(&mut self) {
+        self.auto_scroll = false;
+        self.offset = self.offset.saturating_sub(self.viewport_height);
+    }
+
+    /// Scroll down by a page.
+    pub fn page_down(&mut self) {
+        self.auto_scroll = false;
+        let max = self.max_offset();
+        self.offset = (self.offset + self.viewport_height).min(max);
+        if self.offset >= max {
+            self.auto_scroll = true;
+        }
+    }
+
+    /// Jump to bottom and re-enable auto-scroll.
+    pub fn scroll_to_bottom(&mut self) {
+        self.auto_scroll = true;
+        self.offset = self.max_offset();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_scroll_follows_content() {
+        let mut s = ScrollState::default();
+        s.set_viewport_height(10);
+        s.set_content_height(20);
+        assert_eq!(s.offset, 10);
+
+        s.set_content_height(30);
+        assert_eq!(s.offset, 20);
+    }
+
+    #[test]
+    fn manual_scroll_disables_auto() {
+        let mut s = ScrollState::default();
+        s.set_viewport_height(10);
+        s.set_content_height(30);
+        assert!(s.auto_scroll);
+
+        s.scroll_up();
+        assert!(!s.auto_scroll);
+        assert_eq!(s.offset, 19);
+    }
+
+    #[test]
+    fn scroll_to_bottom_re_enables_auto() {
+        let mut s = ScrollState::default();
+        s.set_viewport_height(10);
+        s.set_content_height(30);
+        s.scroll_up();
+        assert!(!s.auto_scroll);
+
+        s.scroll_to_bottom();
+        assert!(s.auto_scroll);
+        assert_eq!(s.offset, 20);
+    }
+
+    #[test]
+    fn scroll_down_at_bottom_re_enables_auto() {
+        let mut s = ScrollState::default();
+        s.set_viewport_height(10);
+        s.set_content_height(30);
+        s.offset = 19;
+        s.auto_scroll = false;
+
+        s.scroll_down();
+        assert!(s.auto_scroll);
+        assert_eq!(s.offset, 20);
+    }
+}


### PR DESCRIPTION
## Summary

Implements F14: runs Claude Code as a headless subprocess via NDJSON streaming
protocol and renders a custom ratatui TUI around the event stream. This is a
probe — working demo quality that validates the architecture for dual-mode
operation (human TUI + future marvel diagnostic view).

**20 commits, ~7,000 lines across 16 files. 94 tests.**

**Status: architecture validated, manual testing incomplete.** Performance/timing
issues observed during initial testing — needs profiling. Portrait positioning
and permission protocol need verification. See finding-010 in orchestrator.

### Architecture

The bridge pattern separates shared infrastructure from the TUI view layer:

- \`src/bridge.rs\` — async subprocess lifecycle, bidirectional NDJSON,
  \`SessionMetrics\` via \`Arc<Mutex<>>\`, tmux statusline integration
- \`src/protocol_ext.rs\` — \`BridgeParser\` (stateful), 17 \`BridgeEvent\` variants
  covering the full Claude Code streaming protocol
- \`src/tui/\` — one consumer of the bridge (the human operator TUI)

A future marvel diagnostic view or headless agent mode consumes the same bridge
without restructuring. No ratatui types in the bridge layer.

### Features by Phase

| Phase | Feature | Details |
|-------|---------|---------|
| 1 | Protocol foundation | Full NDJSON vocabulary (17 event types), \`BridgeParser\`, \`ConversationItem\` turn model, \`AppStatus\` state machine, 45ms/2KB text batching |
| 2 | Diff rendering | Unified diffs for Edit (green/red +/-), tool-specific renderers for Read/Write/Bash/Grep/Glob, expandable output (Ctrl+X) |
| 3 | Permission mode | Shift+Tab cycles Default→AcceptEdits→Plan→Auto→Bypass, inline approval dialog ([a]llow/[d]eny), status bar indicator |
| 4 | Slash commands | /clear /help /cost /exit /login /compact /model, dynamic tab completion from system/init, @ file path completion, command forwarding |
| 5 | Keyboard shortcuts | Cursor-positioned input (Ctrl+A/E/W/U), left/right arrows, Delete, mouse wheel scroll, Alt+T thinking toggle |
| 6 | Thinking blocks | Collapsed with char count + spinner while streaming, expanded with bordered panel, Alt+T global toggle |
| 7 | Markdown rendering | Fenced code blocks, headers, bullets, numbered lists, blockquotes, horizontal rules, inline bold/italic/code, panic-safe with fast-path skip |
| 8 | Transcript mode | Ctrl+O cycles normal→transcript→focus. Transcript dumps to native scrollback. Focus hides chrome. |

### Additional Features

- **Portrait overlay**: persona portrait in upper-right or lower-right with
  dynamic sizing from actual image dimensions. Ctrl+P position, Alt+P on/off, Alt+S cycle size.
- **Input expansion**: input area grows vertically as text wraps
- **Paste support**: bracketed paste inserts at cursor
- **Input history**: up/down arrow cycling with draft preservation
- **Auto-clearing notifications**: status messages expire after 5 seconds

### Keybindings

| Key | Action |
|-----|--------|
| Ctrl+C | Quit |
| Ctrl+O | Cycle transcript mode (normal/transcript/focus) |
| Ctrl+X | Toggle expand tool output |
| Ctrl+A / Ctrl+E | Cursor to start/end of line |
| Ctrl+W | Delete word backward |
| Ctrl+U | Clear input line |
| Ctrl+P | Toggle portrait position (top/bottom) |
| Ctrl+G | Open external editor (stubbed) |
| Alt+P | Toggle portrait on/off |
| Alt+S | Cycle portrait size |
| Alt+T | Toggle thinking blocks |
| Shift+Tab | Cycle permission mode |
| Tab | Complete slash commands / @ file paths |
| Up/Down | Input history |
| Left/Right | Cursor movement |
| PageUp/PageDown | Scroll conversation |
| Mouse wheel | Scroll conversation |

### Reference Architecture

Patterns adopted from adversarial review of four Rust reimplementations
(session-011, [research doc](docs/research/rust-claude-reimplementations-20260410.md)):

- **AppStatus state machine** — validated by srg-claude-code-rust (Apache-2.0)
- **Text batching** — 45ms/2KB from pi_agent_rust (study only, MIT+rider)
- **Tool-specific permission dialogs** — inspired by claurst (ideas only, GPL-3.0)
- **Panic-safe markdown** — catch_unwind pattern from srg-claude-code-rust

### Plan Documents

- [Original probe plan](docs/research/tui-prototype-plan-20260410.md)
- [Dual-mode bridge plan](docs/research/tui-prototype-plan-dual-mode-20260410.md)
- [8-phase parity plan](docs/research/tui-parity-plan-20260410.md)

### Known Issues

- **Performance/timing issues** observed during testing — needs profiling
- **Portrait positioning** may still have alignment issues depending on terminal/font
- **Permission response protocol** (send_permission_response) untested against live Claude Code hooks
- External editor (Ctrl+G) is stubbed
- Diagnostics placeholder (empty Vec on ToolCallItem) awaits LSP integration
- Per-block thinking expand/collapse (currently global toggle only)
- Render caching (two-layer cache from plan) not yet implemented
- VCR cassette testing (from plan) not yet implemented

### Dependencies Added

| Crate | License | Notes |
|-------|---------|-------|
| ratatui 0.30 | MIT | TUI framework |
| crossterm 0.29 | MIT | Terminal handling |
| ratatui-image 10.0 | MIT | Portrait overlay |
| image 0.25 | MIT | Image loading |
| tokio 1 | MIT | Async bridge I/O |
| similar 2 | MIT | Diff rendering (was transitive) |

### cargo deny

All four categories pass: advisories ok, bans ok, licenses ok, sources ok.

- RUSTSEC-2026-0009 (time 0.3.45) exempted — fix requires Rust 1.88, MSRV is 1.85,
  we don't parse user RFC 2822 dates
- tmux-cmc git source explicitly allowed
- License list: permissive only (MIT, Apache-2.0, BSD, ISC, CC0, Zlib, 0BSD, BSL-1.0, Unicode-3.0)

## Test plan

- [x] \`cargo build\` — compiles clean
- [x] \`cargo test\` — 94 tests pass
- [x] \`cargo clippy -- -D warnings\` — no warnings
- [x] \`cargo +nightly fmt --all -- --check\` — formatted
- [x] \`cargo deny check\` — all categories pass
- [ ] Manual: \`cargo run -- tui\` — verify conversation, tool calls, portrait
- [ ] Manual: keybinding verification per table above
- [ ] Manual: permission mode cycling and approval dialog
- [ ] Performance profiling for observed timing issues
- [ ] Portrait positioning verification across terminal sizes