### PR TITLE
fix(tui): skip picker stdio query under marvel to stop inject race

### DIFF
--- a/src/tui/portrait_widget.rs
+++ b/src/tui/portrait_widget.rs
@@ -59,8 +59,24 @@ impl PortraitWidget {
     ///
     /// Must be called AFTER `crossterm::terminal::enable_raw_mode()` and
     /// BEFORE `Terminal::new()`.
+    ///
+    /// When running under marvel (detected via `MARVEL_SESSION` env
+    /// var), skip `Picker::from_query_stdio()`. The query writes a
+    /// terminal-capability escape sequence to stdout and synchronously
+    /// reads the response from stdin. Under marvel-managed tmux panes,
+    /// any bytes the control plane sends via `marvel inject` during
+    /// that window are consumed by this query — not delivered as key
+    /// events — producing a silent "first-keystrokes lost" race on
+    /// cold-start sessions. See aae-orc-9cp.
+    ///
+    /// Marvel-managed sessions still honour `FORESTAGE_IMAGE_PROTOCOL`
+    /// if the operator has manually selected a protocol.
     pub fn new() -> Option<Self> {
-        let picker = picker_from_env().or_else(|| Picker::from_query_stdio().ok())?;
+        let picker = if std::env::var_os("MARVEL_SESSION").is_some() {
+            picker_from_env()?
+        } else {
+            picker_from_env().or_else(|| Picker::from_query_stdio().ok())?
+        };
         Some(Self {
             picker,
             image_state: None,


### PR DESCRIPTION
## Summary

Root-cause the cold-start inject race on marvel-managed forestage sessions (`aae-orc-9cp`).

### The race

\`Picker::from_query_stdio()\` in \`portrait_widget.rs::new()\` writes a terminal-capability escape sequence to stdout at startup and **synchronously reads the response from stdin**. Under marvel-managed tmux panes — where tmux typically does not forward kitty-graphics queries — the read blocks until timeout, and **any bytes \`marvel inject\` delivers during that window are consumed by the query**, never reaching the key-event reader.

Observable symptom: the first \`marvel inject\` on a freshly-spawned forestage session silently vanishes — no text in the input box, no user message in the conversation area, no reply from claude. Subsequent injects work because the query window has closed. Hit twice during session-026 live demos against Skippy's desk fleet.

### Fix

Detect \`MARVEL_SESSION\` (already set by marvel's forestage adapter at spawn time) and skip the stdio query. Fall back to \`picker_from_env()\` only. Operators who want portraits in marvel-managed sessions can opt in via \`FORESTAGE_IMAGE_PROTOCOL\`.

Standalone forestage (no \`MARVEL_SESSION\` in env) is unchanged — the query still runs for protocol auto-detection as before.

## Test plan

- [x] \`cargo test --lib\` — 130 / 130 passing
- [x] \`cargo build\` clean
- [x] \`just lint\` / deny clean
- [ ] Validate on Skippy's Pi 5 desk fleet: marvel work forestage-team.yaml, immediate \`marvel inject\` on a fresh session, verify the first inject now lands. Previously required waiting N seconds or pre-warming with a throwaway inject.

Refs: aae-orc-9cp