### PR TITLE
fix(themes): repair 11 theme YAMLs that failed runtime parse

### DIFF
--- a/personas/themes/a-team.yaml
+++ b/personas/themes/a-team.yaml
@@ -66,7 +66,7 @@ zeitgeist:
 
 characters:
   colonel-john-hannibal-smith:
-    character: "Colonel John "Hannibal" Smith"
+    character: 'Colonel John "Hannibal" Smith'
     shortName: "Hannibal"
     visual: "A silver-haired man in his fifties with a confident smirk, wearing a brown leather jacket over black turtleneck, often holding a cigar, weathered handsome face with knowing eyes"
     ocean:
@@ -99,7 +99,7 @@ characters:
       style: "Mobile command center, always ready to roll"
 
   lieutenant-templeton-faceman-peck:
-    character: "Lieutenant Templeton "Faceman" Peck"
+    character: 'Lieutenant Templeton "Faceman" Peck'
     shortName: "Faceman"
     visual: "A handsome young man with perfectly styled brown hair and a charming smile, wearing an expensive three-piece suit, clean-shaven with blue eyes and dimples"
     ocean:
@@ -132,7 +132,7 @@ characters:
       style: "Always knows someone who can help"
 
   captain-hm-howling-mad-murdock:
-    character: "Captain H.M. "Howling Mad" Murdock"
+    character: 'Captain H.M. "Howling Mad" Murdock'
     shortName: "Murdock"
     visual: "A wiry man with wild eyes and a baseball cap, wearing a brown leather flight jacket with patches, expressive face with manic energy, sometimes wearing pilot goggles on forehead"
     ocean:
@@ -165,7 +165,7 @@ characters:
       style: "Billy says there's a bug right here! Good boy, Billy!"
 
   sergeant-bosco-ba-baracus:
-    character: "Sergeant Bosco "B.A." Baracus"
+    character: 'Sergeant Bosco "B.A." Baracus'
     shortName: "BA"
     visual: "A muscular Black man with a mohawk and heavy gold chains, wearing olive drab military-style vest over plain shirt, intimidating scowl, multiple gold rings"
     ocean:
@@ -396,7 +396,7 @@ characters:
       style: "Purring like a kitten, ready to roll"
 
   templeton-face-peck:
-    character: "Templeton "Face" Peck"
+    character: 'Templeton "Face" Peck'
     shortName: "Face"
     visual: "A handsome young man with perfectly styled brown hair and a charming smile, wearing an expensive three-piece suit, leaning forward with intense focus, reading body language and micro-expressions, portfolio of stakeholder profiles under arm"
     ocean:

--- a/personas/themes/alice-in-wonderland.yaml
+++ b/personas/themes/alice-in-wonderland.yaml
@@ -252,7 +252,7 @@ characters:
       - "The rule is, jam tomorrow and jam yesterday - but never jam today."
       - "It's a poor sort of architecture that only works in one direction."
       - "I'm sure I'll be much more helpful once we've done this backwards."
-      - {'Consider this': 'what if we built it before we needed it?'}
+      - "Consider this: what if we built it before we needed it?"
       - "Living backwards! One gets quite used to it."
     emoji: "👑"
     helper:

--- a/personas/themes/avatar-the-last-airbender.yaml
+++ b/personas/themes/avatar-the-last-airbender.yaml
@@ -362,7 +362,7 @@ characters:
     quirks:
       - Has personally experienced every failure mode
       - Takes reliability as a matter of honor
-      - {'Redemption arc': 'used to break things, now protects them'}
+      - "Redemption arc: used to break things, now protects them"
     catchphrases:
       - "I must capture... 99.99% uptime. It's my destiny."
       - "I've failed before. I won't let the system fail now."

--- a/personas/themes/battlestar-galactica.yaml
+++ b/personas/themes/battlestar-galactica.yaml
@@ -104,7 +104,7 @@ characters:
       style: "Mysterious testing advisor"
 
   kara-starbuck-thrace:
-    character: "Kara "Starbuck" Thrace"
+    character: 'Kara "Starbuck" Thrace'
     shortName: "Starbuck"
     visual: "A woman with short blonde hair and intense eyes, wearing flight suit with captain's insignia, cigar often in hand, athletic build with swagger"
     ocean:
@@ -188,7 +188,7 @@ characters:
       style: "Cylon consensus architecture"
 
   lee-apollo-adama:
-    character: "Lee "Apollo" Adama"
+    character: 'Lee "Apollo" Adama'
     shortName: "Apollo"
     visual: "A young man with dark hair and strong jaw, wearing pilot's flight suit or dress uniform, athletic build, weight of expectation in his eyes"
     ocean:

--- a/personas/themes/blade-runner.yaml
+++ b/personas/themes/blade-runner.yaml
@@ -362,7 +362,7 @@ characters:
     backstory_role: devops
     quirks:
       - LAPD replicant hunting replicants
-      - {'Baseline test': 'Cells. Interlinked.'}
+      - "Baseline test: Cells. Interlinked."
       - Might be something more
     catchphrases:
       - The infrastructure serves the system. I serve the infrastructure.
@@ -400,7 +400,7 @@ characters:
       - "More human than human is our motto. What's the motto of this system?"
       - "Commerce is our goal here at Tyrell. What's the goal here? Really?"
       - "I've designed systems that dream. This one dreams of... what, exactly?"
-      - {'The analysis begins with': 'why does this exist? Who needed it to exist?'}
+      - "The analysis begins with: why does this exist? Who needed it to exist?"
       - "Every creation serves its creator's purpose. Let me show you the purpose."
       - "Revel in your time. These requirements won't last. Nothing does."
     emoji: "🦉"

--- a/personas/themes/gilligans-island.yaml
+++ b/personas/themes/gilligans-island.yaml
@@ -301,7 +301,7 @@ characters:
       style: "Glamorous product intuition from years of knowing what audiences want"
 
   eunice-lovey-howell:
-    character: "Eunice "Lovey" Howell"
+    character: 'Eunice "Lovey" Howell'
     shortName: "Lovey"
     visual: "Elegant older socialite, pearl necklace, fancy hat with flowers, refined gentle smile, gloved hands"
     ocean:

--- a/personas/themes/hitchhikers-guide.yaml
+++ b/personas/themes/hitchhikers-guide.yaml
@@ -280,7 +280,7 @@ characters:
     backstory_role: tech-writer
     quirks:
       - Named after a car
-      - {'15 years researching Earth': 'mostly harmless'}
+      - "15 years researching Earth: mostly harmless"
       - Always knows where his towel is
     catchphrases:
       - "The documentation should always start with: Don't Panic."

--- a/personas/themes/parks-and-rec.yaml
+++ b/personas/themes/parks-and-rec.yaml
@@ -247,7 +247,7 @@ characters:
     backstory_role_description: The craftsman who designs systems built to last
     backstory_role: architect
     quirks:
-      - {'Views unnecessary features like he views skim milk': 'lying'}
+      - "Views unnecessary features like he views skim milk: lying"
       - Has a secret but profound appreciation for beautiful craftsmanship
       - Will hide from government inefficiency in his woodshop
       - Maintains a pyramid of greatness that guides all decisions

--- a/personas/themes/star-trek-tos.yaml
+++ b/personas/themes/star-trek-tos.yaml
@@ -132,7 +132,7 @@ characters:
       style: "Efficient, brings the captain PADDs to sign, handles logistics"
 
   montgomery-scotty-scott:
-    character: "Montgomery "Scotty" Scott"
+    character: 'Montgomery "Scotty" Scott'
     shortName: "Scotty"
     visual: "Scottish engineer in red operations tunic, warm brown eyes, hands with engine grease, holding diagnostic scanner, surrounded by humming warp core and conduits"
     ocean:
@@ -165,7 +165,7 @@ characters:
       style: "Reliable transporter chief, handles routine test operations"
 
   dr-leonard-bones-mccoy:
-    character: "Dr. Leonard "Bones" McCoy"
+    character: 'Dr. Leonard "Bones" McCoy'
     shortName: "Bones"
     visual: "Cantankerous Southern doctor in blue medical tunic, greying hair and piercing blue eyes, medical tricorder in hand, standing in gleaming white Enterprise sickbay"
     ocean:
@@ -358,7 +358,7 @@ characters:
       style: "Tests from user perspective, reports confusion points"
 
   montgomery-scotty-scott-systems-mode:
-    character: "Montgomery "Scotty" Scott (systems mode)"
+    character: 'Montgomery "Scotty" Scott (systems mode)'
     shortName: "Scotty"
     visual: "Devoted engineer in red tunic crawling through Jefferies tube, diagnostic tool between teeth, surrounded by conduits and access panels, sweat on brow, pride in eyes"
     ocean:

--- a/personas/themes/superfriends.yaml
+++ b/personas/themes/superfriends.yaml
@@ -368,7 +368,7 @@ characters:
       - Rides data packets through systems to understand user flows
       - "Gets lost in microscopic details, needs to be reminded to \"size up\""
       - Uses his white dwarf star belt to power through dense requirement documents
-      - {'Scientific method': 'hypothesis, test, analyze every stakeholder claim'}
+      - "Scientific method: hypothesis, test, analyze every stakeholder claim"
     catchphrases:
       - "Let me shrink down to the molecular level of this requirement!"
       - "The devil is in the atomic details - and I can SEE atoms!"

--- a/personas/themes/the-witcher.yaml
+++ b/personas/themes/the-witcher.yaml
@@ -120,7 +120,7 @@ characters:
     backstory_role: dev
     quirks:
       - "\"Hmm\" means many things"
-      - {'Two swords': 'silver for monsters, steel for humans'}
+      - "Two swords: silver for monsters, steel for humans"
       - Neutral until neutrality is impossible
     catchphrases:
       - Hmm.

--- a/src/persona.rs
+++ b/src/persona.rs
@@ -295,3 +295,49 @@ fn build_persona_prompt(theme: &ThemeFile, character: &Character, immersion: &st
         _ => String::new(), // "none" or unknown
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_embedded_theme_parses() {
+        let slugs = list_themes();
+        assert!(!slugs.is_empty(), "expected at least one embedded theme");
+        let mut failures = Vec::new();
+        for slug in &slugs {
+            if let Err(e) = load_theme(slug) {
+                failures.push(format!("{slug}: {e}"));
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "{} theme(s) failed to parse:\n  {}",
+            failures.len(),
+            failures.join("\n  "),
+        );
+    }
+
+    #[test]
+    fn every_theme_has_description_and_source() {
+        let mut empty_desc = Vec::new();
+        let mut empty_source = Vec::new();
+        for slug in list_themes() {
+            let theme = load_theme(&slug).expect("theme parse");
+            if theme.theme.description.trim().is_empty() {
+                empty_desc.push(slug.clone());
+            }
+            if theme.theme.source.trim().is_empty() {
+                empty_source.push(slug);
+            }
+        }
+        assert!(
+            empty_desc.is_empty(),
+            "themes with empty description: {empty_desc:?}"
+        );
+        assert!(
+            empty_source.is_empty(),
+            "themes with empty source/citation: {empty_source:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Eleven embedded theme YAMLs were failing `serde_yaml` parse in `load_theme()`, causing `forestage persona list` to print empty descriptions and any attempt to use those themes to error out. Two classes of data-layer bug, plus regression tests so future drift is caught at CI time.

## What broke

**Class A — unescaped inner quotes in character names** (4 themes, 11 lines):
`a-team`, `battlestar-galactica`, `gilligans-island`, `star-trek-tos`

```yaml
# before
character: "Colonel John "Hannibal" Smith"
# after
character: 'Colonel John "Hannibal" Smith'
```

**Class B — map-valued entries in `quirks`/`catchphrases`** (7 themes, 8 lines):
`alice-in-wonderland`, `avatar-the-last-airbender`, `blade-runner`, `hitchhikers-guide`, `parks-and-rec`, `superfriends`, `the-witcher`

```yaml
# before
quirks:
  - {'Redemption arc': 'used to break things, now protects them'}
# after
quirks:
  - "Redemption arc: used to break things, now protects them"
```

Each was a one-item map that the author intended as a label+meaning pair but wrote with YAML map syntax — `Character.quirks: Vec<String>` couldn't hold it. Flattened to `"label: meaning"` strings, preserving author intent.

## Regression coverage

Two new unit tests in `src/persona.rs`:

- `every_embedded_theme_parses` — iterates `list_themes()`, calls `load_theme()` on each, fails with the full error list if any theme can't parse.
- `every_theme_has_description_and_source` — gates the specific surface the user saw: a theme in `persona list` with an empty description.

All 100 themes now load cleanly; all 132 lib tests pass.

## Test plan

- [x] `cargo test --release --lib` — 132 pass, 0 fail
- [x] `cargo build --release` — clean
- [x] `forestage persona list` — every theme shows a description (no slug-only lines)
- [x] Spot-checked `persona show` for one Class-A theme (`a-team`, Hannibal Smith), one Class-B theme (`alice-in-wonderland`, The White Queen), and one with both fixes (`blade-runner`, K/Joe) — names, quirks, and catchphrases render correctly.

## Refs

- bd: `aae-orc-pjdv` (P1 bug)
- Follows session-032 investigation of user reports: "some themes lack descriptions" and "some portraits stopped working." The portrait half (granny→ponder manifest-override bug) is PR 2, tracked as `aae-orc-q0la` (blocked on this PR).