### PR TITLE
fix(persona,portrait): retire legacy role interpretation + fix granny→ponder manifest bug

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -32,12 +32,13 @@ pub struct PersonaConfig {
     /// Theme slug (the roster to draw from).
     #[serde(default = "default_theme")]
     pub theme: String,
-    /// Character slug within the theme (direct lookup).
-    /// Takes precedence over legacy `role` for character resolution.
+    /// Character slug within the theme (the --persona flag / "costume").
+    /// This is the sole character selector under the B14 agent taxonomy.
     #[serde(default)]
     pub character: String,
-    /// Legacy: role name used as character lookup key in pre-taxonomy themes.
-    /// Still works via get_character_by_legacy_role() for backwards compat.
+    /// Job assignment(s) on this team — free-form, CSV supported
+    /// (e.g. "reviewer,troubleshooter"). Passed to `build_full_prompt`
+    /// as role-layer context. Not a character lookup key.
     #[serde(default = "default_role")]
     pub role: String,
     /// Professional identity / lens ("homicide detective", "systems architect").

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,14 +240,15 @@ enum PersonaAction {
     /// List available themes
     List,
 
-    /// Show theme details
+    /// Show theme details (or a single character card with --agent)
     Show {
         /// Theme slug
         name: String,
 
-        /// Show specific agent role
-        #[arg(long, default_value = "dev")]
-        agent: String,
+        /// Character slug — show card for this character. Omit to list
+        /// the full roster.
+        #[arg(long)]
+        agent: Option<String>,
 
         /// Display portrait inline (Kitty/Ghostty terminals)
         #[arg(short = 'p', long)]
@@ -268,6 +269,17 @@ enum PersonaAction {
 
     /// Show portrait cache status
     Portraits,
+}
+
+/// Trim a string to a single line and cap its length for table-style output.
+fn truncate_one_line(s: &str, max: usize) -> String {
+    let one_line = s.lines().next().unwrap_or("").trim();
+    if one_line.chars().count() <= max {
+        return one_line.to_string();
+    }
+    let mut out: String = one_line.chars().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
 }
 
 fn main() -> anyhow::Result<()> {
@@ -430,16 +442,42 @@ fn main() -> anyhow::Result<()> {
                 portrait_size,
             } => {
                 let cfg = config::load_config(cli_overrides)?;
+                let theme = persona::load_theme(&name)?;
+
+                let Some(agent_slug) = agent else {
+                    // No character selected — print roster summary.
+                    println!("Theme: {} ({})", theme.theme.name, theme.category);
+                    println!("Description: {}", theme.theme.description);
+                    if !theme.theme.source.is_empty() {
+                        println!("Source: {}", theme.theme.source);
+                    }
+                    if let Some(title) = &theme.theme.user_title {
+                        println!("User title: {title}");
+                    }
+                    let mut chars: Vec<_> = theme.characters.iter().collect();
+                    chars.sort_by_key(|(k, _)| k.as_str());
+                    println!();
+                    println!("Characters ({}):", chars.len());
+                    for (slug, c) in chars {
+                        println!(
+                            "  {:<40} {} — {}",
+                            slug,
+                            c.character,
+                            truncate_one_line(&c.style, 60)
+                        );
+                    }
+                    println!();
+                    println!("Use 'forestage persona show {name} --agent <slug>' for details.");
+                    return Ok(());
+                };
 
                 // Auto-download portraits if showing and not cached
                 if show_portrait {
                     let _ = download::ensure_portraits(&name, &cfg.portrait);
                 }
 
-                let theme = persona::load_theme(&name)?;
-                let character_data = persona::get_character(&theme, &agent)
-                    .or_else(|_| persona::get_character_by_legacy_role(&theme, &agent))?;
-                let portraits = portrait::resolve_portrait(&name, character_data, Some(&agent));
+                let character_data = persona::get_character(&theme, &agent_slug)?;
+                let portraits = portrait::resolve_portrait(&name, character_data);
 
                 // Portrait before card (position: top)
                 if show_portrait && portrait_position == "top" {
@@ -457,17 +495,8 @@ fn main() -> anyhow::Result<()> {
                 if let Some(title) = &theme.theme.user_title {
                     println!("User title: {title}");
                 }
-                println!("Characters: {}", {
-                    let mut chars: Vec<_> = theme.characters.keys().collect();
-                    chars.sort();
-                    chars
-                        .iter()
-                        .map(|s| s.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                });
                 println!();
-                println!("Agent: {} (role: {agent})", character_data.character);
+                println!("Character: {} ({agent_slug})", character_data.character);
                 println!("  Style: {}", character_data.style);
                 println!("  Expertise: {}", character_data.expertise);
                 println!("  Trait: {}", character_data.r#trait);

--- a/src/persona.rs
+++ b/src/persona.rs
@@ -145,38 +145,25 @@ pub fn get_character<'a>(theme: &'a ThemeFile, slug: &str) -> Result<&'a Charact
         })
 }
 
-/// Backwards-compatible alias — get a character by the old role key.
-/// Searches backstory_role fields for a match. Used during migration.
-pub fn get_character_by_legacy_role<'a>(theme: &'a ThemeFile, role: &str) -> Result<&'a Character> {
-    theme
-        .characters
-        .values()
-        .find(|c| c.backstory_role == role)
-        .ok_or_else(|| ForestageError::CharacterNotFound {
-            character: format!("(legacy role: {role})"),
-            theme: theme.theme.name.clone(),
-        })
-}
-
 use crate::config::PersonaConfig;
 
-/// Resolve a character from config, handling the precedence:
-/// 1. config.character (--persona flag, direct slug lookup)
-/// 2. config.role (legacy: lookup by backstory_role)
-/// 3. first character in the roster (fallback)
+/// Resolve a character from config.
+///
+/// Under the B14 agent taxonomy, persona selection is by character slug.
+/// `config.role` is a job-assignment string (passed to `build_full_prompt`),
+/// not a character lookup key.
+///
+/// Precedence:
+/// 1. `config.character` (--persona flag, direct slug lookup)
+/// 2. First character in the roster, alphabetical (fallback when no
+///    character is specified)
 pub fn resolve_character<'a>(
     theme: &'a ThemeFile,
     config: &PersonaConfig,
 ) -> Result<&'a Character> {
-    // Direct character slug takes precedence
     if !config.character.is_empty() {
         return get_character(theme, &config.character);
     }
-    // Legacy: role-based lookup
-    if !config.role.is_empty() {
-        return get_character_by_legacy_role(theme, &config.role);
-    }
-    // Fallback: first character alphabetically
     let mut keys: Vec<_> = theme.characters.keys().collect();
     keys.sort();
     keys.first()

--- a/src/portrait.rs
+++ b/src/portrait.rs
@@ -1,8 +1,6 @@
-use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::OnceLock;
 
 use crate::config::PortraitConfig;
 use crate::persona::Character;
@@ -59,20 +57,6 @@ pub fn portrait_cache_dir() -> PathBuf {
     data_dir.join("forestage/portraits")
 }
 
-/// Cached manifest: theme-slug -> { role -> filename-stem }.
-static MANIFEST: OnceLock<HashMap<String, HashMap<String, String>>> = OnceLock::new();
-
-fn load_manifest() -> &'static HashMap<String, HashMap<String, String>> {
-    MANIFEST.get_or_init(|| {
-        let path = portrait_cache_dir().join("manifest.json");
-        let content = match fs::read_to_string(&path) {
-            Ok(c) => c,
-            Err(_) => return HashMap::new(),
-        };
-        serde_json::from_str(&content).unwrap_or_default()
-    })
-}
-
 /// Normalize a name for portrait filename matching.
 fn normalize_stem(name: &str) -> String {
     name.to_lowercase()
@@ -84,16 +68,22 @@ fn normalize_stem(name: &str) -> String {
         .collect()
 }
 
-/// Resolve portrait paths for a given theme/agent/role.
+/// Resolve portrait paths for a given theme + character.
 ///
-/// Resolution order:
-/// 1. Manifest entry (authoritative)
-/// 2. shortName (normalized)
-/// 3. Full character name (normalized)
-/// 4. First name only
+/// Derived-stem lookup order:
+/// 1. shortName (normalized)
+/// 2. Full character name (normalized)
+/// 3. First name only
 ///
-/// For each candidate stem, tries exact match then prefix match in each size directory.
-pub fn resolve_portrait(theme_slug: &str, agent: &Character, role: Option<&str>) -> PortraitPaths {
+/// For each candidate stem, tries exact match then prefix match in each
+/// size directory (small/medium/large/original).
+///
+/// The legacy `manifest.json` role-keyed override was removed in the
+/// B14 agent taxonomy cleanup: role is a job assignment, not a persona
+/// selector, so the manifest's role-key override served the wrong
+/// portrait whenever --persona and --role referred to different
+/// characters (the granny→ponder class of bug).
+pub fn resolve_portrait(theme_slug: &str, agent: &Character) -> PortraitPaths {
     let cache_dir = portrait_cache_dir();
     let theme_dir = cache_dir.join(theme_slug);
 
@@ -108,41 +98,29 @@ pub fn resolve_portrait(theme_slug: &str, agent: &Character, role: Option<&str>)
         return paths;
     }
 
-    // Build candidate stems
-    let manifest = load_manifest();
+    // Build candidate stems from character fields.
     let mut stems: Vec<String> = Vec::new();
-
-    // 1. Manifest (authoritative)
-    if let Some(role_key) = role {
-        if let Some(stem) = manifest.get(theme_slug).and_then(|m| m.get(role_key)) {
-            stems.push(stem.clone());
+    if let Some(short) = &agent.short_name {
+        let s = normalize_stem(short);
+        if !s.is_empty() {
+            stems.push(s);
         }
     }
-
-    // 2-4. Derived stems (fallback)
-    if stems.is_empty() {
-        if let Some(short) = &agent.short_name {
-            let s = normalize_stem(short);
-            if !s.is_empty() {
-                stems.push(s);
-            }
-        }
-        let char_stem = normalize_stem(&agent.character);
-        if !char_stem.is_empty() && !stems.contains(&char_stem) {
-            stems.push(char_stem);
-        }
-        let first_name = agent
-            .character
-            .split_whitespace()
-            .next()
-            .unwrap_or("")
-            .to_lowercase()
-            .chars()
-            .filter(|c| c.is_alphanumeric())
-            .collect::<String>();
-        if !first_name.is_empty() && !stems.contains(&first_name) {
-            stems.push(first_name);
-        }
+    let char_stem = normalize_stem(&agent.character);
+    if !char_stem.is_empty() && !stems.contains(&char_stem) {
+        stems.push(char_stem);
+    }
+    let first_name = agent
+        .character
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_lowercase()
+        .chars()
+        .filter(|c| c.is_alphanumeric())
+        .collect::<String>();
+    if !first_name.is_empty() && !stems.contains(&first_name) {
+        stems.push(first_name);
     }
 
     // Search each size directory
@@ -316,4 +294,51 @@ pub fn cache_status() -> (usize, usize) {
     }
 
     (themes, images)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_stem_lowercases_and_slugifies() {
+        assert_eq!(normalize_stem("Granny Weatherwax"), "granny-weatherwax");
+        assert_eq!(normalize_stem("DEATH"), "death");
+        assert_eq!(normalize_stem("Lu-Tze"), "lu-tze");
+        assert_eq!(
+            normalize_stem("Lord Havelock Vetinari"),
+            "lord-havelock-vetinari"
+        );
+    }
+
+    #[test]
+    fn normalize_stem_strips_punctuation() {
+        assert_eq!(
+            normalize_stem("Dr. Leonard \"Bones\" McCoy"),
+            "dr-leonard-bones-mccoy"
+        );
+        assert_eq!(normalize_stem("B.A. Baracus"), "ba-baracus");
+    }
+
+    #[test]
+    fn resolve_portrait_no_cache_returns_empty() {
+        // Nonexistent theme dir — no ambient state required.
+        let character = Character {
+            character: "Granny Weatherwax".into(),
+            short_name: Some("Granny".into()),
+            visual: None,
+            ocean: None,
+            style: String::new(),
+            expertise: String::new(),
+            r#trait: String::new(),
+            backstory_role: String::new(),
+            backstory_role_description: String::new(),
+            quirks: Vec::new(),
+            catchphrases: Vec::new(),
+            emoji: None,
+            helper: None,
+        };
+        let paths = resolve_portrait("__nonexistent_theme_fixture__", &character);
+        assert!(!paths.has_any());
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -107,8 +107,7 @@ pub async fn run_tui(config: &ForestageConfig) -> Result<()> {
     // Resolve portrait
     let theme = persona::load_theme(&config.persona.theme)?;
     let character = persona::resolve_character(&theme, &config.persona)?;
-    let portrait_paths =
-        portrait::resolve_portrait(&config.persona.theme, character, Some(&config.persona.role));
+    let portrait_paths = portrait::resolve_portrait(&config.persona.theme, character);
 
     // Terminal setup: raw mode FIRST, then picker query, then terminal
     enable_raw_mode().map_err(|e| crate::error::ForestageError::Session {


### PR DESCRIPTION
## Summary

Two entangled bugs, one fix: the B14 agent taxonomy (session-022) redefined `--role` as a free-form job assignment, but two resolution paths still treated role as a character lookup key. Most visibly, this caused `--persona granny-weatherwax --role dev` to display **Ponder Stibbons' portrait**, because `portraits/manifest.json` was keyed by legacy role names and consulted as authoritative.

Depends on #57 (11 theme YAMLs — merged).

## What broke

1. **`persona::resolve_character`** had a phase-2 fallback to `get_character_by_legacy_role`, matching `Character.backstory_role`.
2. **`portrait::resolve_portrait`** consulted `~/.local/share/forestage/portraits/manifest.json` as authoritative, keyed by legacy role names (`dev`, `reviewer`, `architect`, …).

Consequence of #2 (user-reported): `--persona X --role Y` served Y's legacy-owner portrait whenever the manifest had Y. Canonical case: `--persona granny-weatherwax --role dev` → `ponder-55233.png` (Ponder Stibbons). Audited across the 4 cached themes (`dune`, `breaking-bad`, `discworld`, `the-expanse`) and fires for ~110 cross-pairings.

## Changes

- **`persona.rs`** — drop `get_character_by_legacy_role` function and the legacy fallback in `resolve_character`. New precedence: `config.character` (--persona, direct slug) → first-in-roster alphabetical fallback.
- **`portrait.rs`** — drop the `role: Option<&str>` parameter on `resolve_portrait`, the `MANIFEST` OnceLock, `load_manifest`, and the manifest lookup branch. Derived-stem lookup (shortName → character → first name) is now the only path. Audit confirmed this covers every cached character correctly.
- **`tui/mod.rs`** — update the single call site.
- **`main.rs`** — `persona show <theme> [--agent <slug>]`: agent is now **optional**. Without it, prints the roster (slug + name + one-line style). With it, prints the character card. Removes the `'dev'` default that would crash on any theme without a legacy dev role. Adds `truncate_one_line` helper.
- **`config.rs`** — update `PersonaConfig.role` docstring. It's a job-assignment string now (used in `build_full_prompt`), not a lookup key. `Character.backstory_role` retained as passive metadata for docs/curation; no code reads it for resolution.

## Regression coverage (new in `src/portrait.rs`)

- `normalize_stem_lowercases_and_slugifies`
- `normalize_stem_strips_punctuation` (covers `Dr. Leonard "Bones" McCoy`, `B.A. Baracus`)
- `resolve_portrait_no_cache_returns_empty`

## Test plan

- [x] `cargo test --release --lib` — 135 pass, 0 fail (+3 new portrait tests on top of PR 57's 132)
- [x] `cargo clippy --release --all-targets -- -D warnings` — clean
- [x] `cargo build --release` — clean
- [x] Manual: `forestage persona show discworld` — prints roster (11 characters, slug + name + truncated style)
- [x] Manual: `forestage persona show discworld --agent granny-weatherwax` — prints Granny's full card
- [x] Manual: granny + role=dev no longer serves Ponder (bug reproduced pre-change, fixed post-change)

## Refs

- bd: `aae-orc-q0la` (P1 bug) — unblocks `aae-orc-jwqz` (PR 3, fuzzy resolution)
- Follows session-032 investigation