### PR TITLE
fix(deps): bump rustls-webpki to patch RUSTSEC-2026-0104

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2180,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Bumps `rustls-webpki` 0.103.12 → 0.103.13 via `cargo update -p rustls-webpki`
- Unblocks CI (cargo-deny fails on [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104))

## Threat
Advisory describes a reachable panic parsing an empty `BIT STRING` in the `onlySomeReasons` element of an `IssuingDistributionPoint` CRL extension. **forestage uses reqwest for portrait CDN downloads but does not perform CRL revocation**, so the bug is not exploitable here — this is a transitive patch bump to satisfy the policy gate.

## Test plan
- [x] `cargo update -p rustls-webpki` — single-package patch bump, no SEMVER churn
- [x] Local pre-push: clippy clean, 150 tests pass
- [ ] CI Cargo Deny job goes green
- [ ] CI Test / Clippy / Rustfmt jobs unaffected