### PR TITLE
cleanup(portrait): retire pre-B14 personas map (code + script + doc + R2)

### DIFF
--- a/docs/design/portrait-distribution.md
+++ b/docs/design/portrait-distribution.md
@@ -3,6 +3,17 @@
 Concrete changes needed in Cloudflare and forestage to ship portrait
 distribution for the 45 themes that already have portraits.
 
+> **Status note (2026-04-26):** the `personas` role→stem map originally
+> described in §2 and emitted by §3's gen-manifest.sh has been retired
+> under the B14 agent taxonomy (orc finding-033). Portrait resolution
+> now derives stems from the `Character` (shortName → full name → first
+> name, prefix-matched against the size directory). See
+> [`docs/agent-taxonomy.md`](../agent-taxonomy.md) for the taxonomy and
+> [`src/portrait.rs::resolve_portrait`](../../src/portrait.rs) for the
+> code. The historical `personas` section in this design is preserved
+> below as design context only — the script no longer emits it and
+> `src/download.rs` no longer reads it.
+
 ---
 
 ## 1. Cloudflare R2 Setup
@@ -63,10 +74,12 @@ Set on upload via rclone flags:
 
 ## 2. Manifest Format
 
+**Current (B14, post-finding-033):**
+
 ```json
 {
   "schema": 1,
-  "updated": "2026-04-11T00:00:00Z",
+  "updated": "2026-04-26T00:00:00Z",
   "base_url": "https://portraits.darkatelier.org/v1",
   "themes": {
     "dune": {
@@ -79,32 +92,69 @@ Set on upload via rclone flags:
       "pack_bytes": 7200000,
       "persona_count": 11
     }
-  },
-  "personas": {
-    "dune": {
-      "orchestrator": "mohiam-44323",
-      "sm": "stilgar-25342",
-      "tea": "kynes-35232",
-      "dev": "paul-54212",
-      "reviewer": "jessica-45343",
-      "architect": "leto-45333",
-      "pm": "irulan-44232",
-      "tech-writer": "thufir-44342",
-      "ux-designer": "alia-34342",
-      "devops": "duncan-35232",
-      "ba": "thufir-54223"
-    }
   }
 }
 ```
 
-**`personas` is the exact shape `portrait.rs:62-74` already deserializes.**
-`load_manifest()` reads `HashMap<String, HashMap<String, String>>` — the
-`personas` field is that type verbatim. On download, extract this field
-and write it to `manifest.json`. No translation.
+`themes` is the only section. Pack URL is derived from `base_url` +
+`/themes/{slug}.tar.gz`. No per-theme URL field — the convention is the
+schema. Portrait resolution does not need a manifest hint at all; see
+[Portrait Resolution](#portrait-resolution) below.
 
-Pack URL derived from `base_url` + `/themes/{slug}.tar.gz`. No per-theme
-URL field needed — the convention is the schema.
+**Historical (pre-B14):** the manifest also carried a `personas` field
+keyed by `theme → role → filename-stem` (e.g. `"dev": "paul-54212"`).
+That map was a role-keyed lookup index used by an earlier
+`portrait.rs` lookup path. It was retired when role became a job
+assignment rather than a character key — `--persona` and `--role`
+could refer to different characters, which made the map serve the
+wrong portrait (the granny→ponder bug class). Existing CDN manifests
+may still carry the field; serde ignores it.
+
+---
+
+## Portrait Resolution
+
+Portrait lookup happens entirely on the client. The manifest tells
+forestage *which themes have packs*; nothing in the manifest tells
+forestage *which file is whose portrait*. Resolution derives the
+filename from the `Character` itself.
+
+For a character with `character: "Granny Weatherwax"` and
+`shortName: "Granny"`, `portrait::resolve_portrait(theme_slug, agent)`
+walks these candidate stems in order:
+
+1. `shortName`, slugified — `"granny"`
+2. Full `character` name, slugified — `"granny-weatherwax"`
+3. First word of the character name, slugified — `"granny"`
+   (deduplicated against earlier entries)
+
+For each size directory (`small/medium/large/original`) under
+`<cache>/<theme>/`, each candidate is tried first as an exact match
+(`<stem>.png`) and then as a prefix match (any `<stem>*.png`). The
+prefix branch handles the CDN's hashed filenames — packs ship
+`granny-35211.png`, `ponder-55233.png`, etc., and the unhashed
+`granny` stem matches by prefix. The first match per size wins.
+
+What this means in practice:
+
+- The pack tarball can use any naming scheme as long as filenames
+  start with the character's `shortName` or first name. CDN packs
+  use a five-digit OCEAN suffix; that's a publishing convention,
+  not a contract.
+- Two characters whose stems collide (Naomi Holden and Naomi
+  Nagata, say, on themes that mix both) need disambiguating
+  short names — the resolver has no theme-aware tiebreak beyond
+  prefix-match alphabetical iteration order.
+- The manifest's old `personas` field (theme → role → stem) was a
+  pre-B14 lookup index. Its role key became meaningless when role
+  became a job assignment, and the override could serve the wrong
+  character's portrait whenever `--persona` and `--role` referred
+  to different characters (the granny→ponder bug class). Removed.
+
+See [`docs/agent-taxonomy.md`](../agent-taxonomy.md) for the broader
+persona/identity/role taxonomy and `src/portrait.rs` for the
+implementation. The behavioral test `resolve_portrait_returns_each_characters_own_file`
+in `src/portrait.rs` is the regression guard.
 
 ---
 
@@ -142,86 +192,25 @@ echo "Packed $count themes to $DIST_DIR"
 
 ### `scripts/portraits/gen-manifest.sh`
 
-Generates manifest.json from packed themes + theme YAMLs.
+Generates manifest.json from packed themes. Reads each pack's
+sha256, byte size, and original-image count to fill `themes`.
 
+Usage:
 ```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-DIST_DIR="${1:?Usage: gen-manifest.sh <dist-dir> <themes-yaml-dir>}"
-THEMES_DIR="${2:?Usage: gen-manifest.sh <dist-dir> <themes-yaml-dir>}"
-BASE_URL="${3:-https://portraits.darkatelier.org/v1}"
-
-# Start JSON
-cat <<HEADER
-{
-  "schema": 1,
-  "updated": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "base_url": "$BASE_URL",
-  "themes": {
-HEADER
-
-# Themes section
-first_theme=true
-for pack in "$DIST_DIR"/*.tar.gz; do
-    [[ ! -f "$pack" ]] && continue
-    theme=$(basename "$pack" .tar.gz)
-    sha=$(cat "$DIST_DIR/${theme}.sha256")
-    bytes=$(stat -f%z "$pack" 2>/dev/null || stat -c%s "$pack" 2>/dev/null)
-    persona_count=$(tar tzf "$pack" | grep "^original/.*\.png$" | wc -l | tr -d ' ')
-
-    $first_theme || printf ",\n"
-    first_theme=false
-    printf '    "%s": {"pack_sha256": "%s", "pack_bytes": %s, "persona_count": %s}' \
-        "$theme" "$sha" "$bytes" "$persona_count"
-done
-
-cat <<MIDDLE
-
-  },
-  "personas": {
-MIDDLE
-
-# Personas section — parse theme YAMLs for role→filename mapping
-# Requires yq (https://github.com/mikefarah/yq)
-first_theme=true
-for pack in "$DIST_DIR"/*.tar.gz; do
-    [[ ! -f "$pack" ]] && continue
-    theme=$(basename "$pack" .tar.gz)
-    yaml="$THEMES_DIR/${theme}.yaml"
-    [[ ! -f "$yaml" ]] && continue
-
-    $first_theme || printf ",\n"
-    first_theme=false
-    printf '    "%s": {' "$theme"
-
-    first_role=true
-    # Extract role→shortName+OCEAN from theme YAML
-    for role in $(yq -r '.agents | keys | .[]' "$yaml" 2>/dev/null); do
-        short=$(yq -r ".agents.\"$role\".shortName // .agents.\"$role\".character" "$yaml" 2>/dev/null | head -1)
-        ocean_o=$(yq -r ".agents.\"$role\".ocean.O // empty" "$yaml" 2>/dev/null)
-        [[ -z "$ocean_o" ]] && continue
-        ocean_c=$(yq -r ".agents.\"$role\".ocean.C // empty" "$yaml" 2>/dev/null)
-        ocean_e=$(yq -r ".agents.\"$role\".ocean.E // empty" "$yaml" 2>/dev/null)
-        ocean_a=$(yq -r ".agents.\"$role\".ocean.A // empty" "$yaml" 2>/dev/null)
-        ocean_n=$(yq -r ".agents.\"$role\".ocean.N // empty" "$yaml" 2>/dev/null)
-        slug=$(echo "$short" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g; s/^-//; s/-$//')
-        stem="${slug}-${ocean_o}${ocean_c}${ocean_e}${ocean_a}${ocean_n}"
-
-        $first_role || printf ", "
-        first_role=false
-        printf '"%s": "%s"' "$role" "$stem"
-    done
-
-    printf "}"
-done
-
-cat <<FOOTER
-
-  }
-}
-FOOTER
+./scripts/portraits/gen-manifest.sh dist/portraits
+./scripts/portraits/gen-manifest.sh dist/portraits https://example.com/v1
 ```
+
+Output is written to stdout — redirect to `dist/portraits/manifest.json`.
+
+The script no longer needs a themes-yaml directory or `yq`. The pre-
+B14 version walked theme YAMLs (`.agents` keys, OCEAN fields,
+`shortName`) to build a role→stem map for the manifest's `personas`
+section. Resolution stopped consulting that map (see
+[Portrait Resolution](#portrait-resolution)) and the section was
+dropped along with the YAML walk.
+
+See the script in-tree for the current 60-line implementation.
 
 ### `scripts/portraits/upload-r2.sh`
 
@@ -279,7 +268,22 @@ Env: `FORESTAGE_PORTRAIT__AUTO_DOWNLOAD=false`
 
 ### 4b. New module: `src/download.rs`
 
-All network operations. Subprocess-based, sync. No new crate dependencies.
+All network operations. Subprocess-based, sync. No new crate
+dependencies.
+
+The original design (preserved below as historical context) declared a
+`personas: HashMap<String, HashMap<String, String>>` field on
+`RemoteManifest` and called `merge_local_manifest()` after extraction
+to write a local `manifest.json` keyed by theme→role→stem. Both have
+been removed. Today the deserializer ignores the CDN's leftover
+`personas` field (serde default), and `ensure_portraits` ends after
+writing the `.complete` sentinel — `portrait::resolve_portrait`
+derives stems from the `Character` directly. See
+[Portrait Resolution](#portrait-resolution).
+
+The current source is in `src/download.rs` — the live file is
+authoritative; the historical excerpt below shows the original
+approach.
 
 ```rust
 //! Portrait pack download via subprocess (curl + tar + openssl).
@@ -638,6 +642,11 @@ pub mod download;
 
 ## 5. Flat Layout Migration
 
+> **Status:** never built. The "match against persona entries" step
+> below was specified pre-B14; under the current taxonomy a migration
+> would derive stems from `Character`, not from a role-keyed map.
+> Left here as design context.
+
 Add to `PortraitAction`:
 
 ```rust
@@ -657,18 +666,28 @@ Implementation:
 
 ## 6. Changes Summary
 
+Original implementation pass:
+
 | File | Change |
 |------|--------|
-| `src/download.rs` | **New** — manifest fetch, pack download, SHA256 verify, extract, merge |
+| `src/download.rs` | **New** — manifest fetch, pack download, SHA256 verify, extract |
 | `src/config.rs` | Add `auto_download: bool` to `PortraitConfig` |
 | `src/main.rs` | Add `Portraits` subcommand, call `ensure_portraits` before TUI |
 | `src/lib.rs` | Add `pub mod download` |
-| `src/portrait.rs` | No changes — existing API consumed as-is |
 | `Cargo.toml` | No new dependencies |
-| `scripts/portraits/` | **New** — pack, gen-manifest, upload scripts (run from PF repo) |
+| `scripts/portraits/` | **New** — pack, gen-manifest, upload scripts |
 
 **Zero new Rust dependencies.** Uses `curl`, `tar`, `openssl` via
 subprocess — all present on macOS and standard Linux.
+
+Post-B14 cleanup pass (this revision):
+
+| File | Change |
+|------|--------|
+| `src/download.rs` | Drop `RemoteManifest.personas` field, drop `merge_local_manifest()`, drop the call site in `ensure_portraits` |
+| `src/portrait.rs` | Drop `manifest.json` role-key override (PR #58); resolution becomes character-derived |
+| `scripts/portraits/gen-manifest.sh` | Drop `personas` section emission and the YAML walk; signature simplifies to `(dist-dir, [base-url])` |
+| `docs/design/portrait-distribution.md` | Add §Portrait Resolution; mark `personas` map as historical |
 
 ---
 
@@ -677,12 +696,12 @@ subprocess — all present on macOS and standard Linux.
 | Test | What |
 |------|------|
 | Unit: `verify_sha256` | Known hash matches, mismatch returns false |
-| Unit: `merge_local_manifest` | Writes correct JSON, merges with existing |
 | Unit: `CacheMeta` serde | Round-trips through JSON |
 | Integration: `ensure_portraits` | Mock HTTP with local file server, verify full flow |
 | Manual: fresh install | `forestage` with no cache → downloads theme → portrait renders |
 | Manual: cached | Second launch → no network, instant |
 | Manual: offline | No network → warns, continues without portrait |
-| Manual: `portraits download --all` | All 45 themes downloaded |
+| Manual: `portraits download --all` | All themes downloaded |
 | Manual: `portraits status` | Shows counts |
 | Manual: `portraits clean dune` | Removes theme dir + sentinel |
+| Behavioral: `resolve_portrait_returns_each_characters_own_file` | Granny + Ponder each resolve to their own pack file (granny→ponder regression guard) |

--- a/scripts/portraits/gen-manifest.sh
+++ b/scripts/portraits/gen-manifest.sh
@@ -1,34 +1,28 @@
 #!/usr/bin/env bash
-# Generate manifest.json from packed theme archives and theme YAML files.
+# Generate manifest.json from packed theme archives.
 #
-# The manifest has two sections:
-#   themes:   pack metadata (sha256, size, persona count)
-#   personas: role → filename-stem mapping (exact format portrait.rs expects)
+# The manifest has one section:
+#   themes: pack metadata (sha256, size, persona count)
 #
-# Requires: yq (https://github.com/mikefarah/yq)
+# Pre-B14 versions of this script also emitted a `personas` map (role
+# → filename-stem) consumed by an old portrait.rs lookup path. That
+# map became inert once portrait resolution moved to deriving stems
+# from the Character itself (orc finding-033, B14 agent taxonomy).
+# Removed entirely from this script + src/download.rs in the same
+# pass; serde ignores any leftover field on already-published
+# manifests.
 #
 # Usage:
-#   ./scripts/portraits/gen-manifest.sh <dist-dir> <themes-yaml-dir> [base-url]
-#   ./scripts/portraits/gen-manifest.sh dist/portraits ~/work/penny-orc/pennyfarthing/pennyfarthing-dist/personas/themes
+#   ./scripts/portraits/gen-manifest.sh <dist-dir> [base-url]
+#   ./scripts/portraits/gen-manifest.sh dist/portraits
 
 set -euo pipefail
 
-DIST_DIR="${1:?Usage: gen-manifest.sh <dist-dir> <themes-yaml-dir> [base-url]}"
-THEMES_DIR="${2:?Usage: gen-manifest.sh <dist-dir> <themes-yaml-dir> [base-url]}"
-BASE_URL="${3:-https://portraits.darkatelier.org/v1}"
-
-if ! command -v yq &>/dev/null; then
-    echo "Error: yq not found. Install with: brew install yq" >&2
-    exit 1
-fi
+DIST_DIR="${1:?Usage: gen-manifest.sh <dist-dir> [base-url]}"
+BASE_URL="${2:-https://portraits.darkatelier.org/v1}"
 
 if [[ ! -d "$DIST_DIR" ]]; then
     echo "Error: dist directory not found: $DIST_DIR" >&2
-    exit 1
-fi
-
-if [[ ! -d "$THEMES_DIR" ]]; then
-    echo "Error: themes directory not found: $THEMES_DIR" >&2
     exit 1
 fi
 
@@ -66,51 +60,6 @@ for theme in "${themes[@]}"; do
     first=false
     printf '    "%s": {"pack_sha256": "%s", "pack_bytes": %s, "persona_count": %s}' \
         "$theme" "$sha" "$bytes" "$persona_count"
-done
-printf '\n  },\n'
-
-# Personas section — parse theme YAMLs for role → filename-stem mapping.
-# Uses a single yq call per theme to extract all role→stem mappings at once,
-# avoiding O(roles × fields) subprocess overhead.
-printf '  "personas": {\n'
-first_theme=true
-for theme in "${themes[@]}"; do
-    yaml="$THEMES_DIR/${theme}.yaml"
-    if [[ ! -f "$yaml" ]]; then
-        echo "Warning: no theme YAML for $theme, skipping persona map" >&2
-        continue
-    fi
-
-    # Extract all role→stem pairs. One yq call gets role, shortName, and OCEAN;
-    # bash handles the slug transformation (yq/Go lacks jq's ascii_downcase/sub).
-    persona_lines=""
-    while IFS=$'\t' read -r role short ocean_o ocean_c ocean_e ocean_a ocean_n; do
-        [[ -z "$role" || -z "$ocean_o" ]] && continue
-        slug=$(echo "$short" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g; s/^-*//; s/-*$//')
-        persona_lines+="${role}"$'\t'"${slug}-${ocean_o}${ocean_c}${ocean_e}${ocean_a}${ocean_n}"$'\n'
-    done < <(yq -r '
-      .agents | to_entries[] |
-      select(.value.ocean.O != null) |
-      [.key, (.value.shortName // (.value.character | split(" ") | .[0])),
-       .value.ocean.O, .value.ocean.C, .value.ocean.E, .value.ocean.A, .value.ocean.N] |
-      @tsv
-    ' "$yaml" 2>/dev/null)
-
-    [[ -z "$persona_lines" ]] && continue
-
-    $first_theme || printf ',\n'
-    first_theme=false
-    printf '    "%s": {' "$theme"
-
-    first_role=true
-    while IFS=$'\t' read -r role stem; do
-        [[ -z "$role" ]] && continue
-        $first_role || printf ', '
-        first_role=false
-        printf '"%s": "%s"' "$role" "$stem"
-    done <<< "$persona_lines"
-
-    printf '}'
 done
 printf '\n  }\n'
 printf '}\n'

--- a/src/download.rs
+++ b/src/download.rs
@@ -17,13 +17,18 @@ const MANIFEST_URL: &str = "https://portraits.darkatelier.org/v1/manifest.json";
 const MANIFEST_CHECK_INTERVAL_SECS: u64 = 86400; // 24h
 
 /// Remote manifest schema.
+///
+/// The CDN's `personas` field (legacy role→stem map) is intentionally
+/// not declared here. serde ignores unknown JSON fields by default, so
+/// the existing manifest still deserializes; the field is unused under
+/// the B14 agent taxonomy because portrait resolution derives stems
+/// from the Character itself (see `portrait::resolve_portrait`).
 #[derive(Debug, serde::Deserialize)]
 struct RemoteManifest {
     #[allow(dead_code)]
     schema: u32,
     base_url: String,
     themes: HashMap<String, ThemeEntry>,
-    personas: HashMap<String, HashMap<String, String>>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -142,11 +147,6 @@ pub fn ensure_portraits(theme: &str, config: &PortraitConfig) -> Result<bool> {
 
     // Write sentinel
     let _ = fs::write(&sentinel, "");
-
-    // Merge persona mapping into local manifest.json
-    if let Some(persona_map) = manifest.personas.get(theme) {
-        merge_local_manifest(&cache, theme, persona_map)?;
-    }
 
     eprintln!("Portrait pack installed for {theme}");
     Ok(true)
@@ -322,33 +322,6 @@ fn verify_sha256(path: &Path, expected: &str) -> Result<bool> {
     let hash = String::from_utf8_lossy(&output.stdout);
     let computed = hash.split_whitespace().next().unwrap_or("");
     Ok(computed == expected)
-}
-
-/// Merge a theme's persona map into the local manifest.json.
-///
-/// The local manifest is the exact format portrait.rs expects:
-/// `{ "theme-slug": { "role": "filename-stem" } }`
-fn merge_local_manifest(
-    cache: &Path,
-    theme: &str,
-    persona_map: &HashMap<String, String>,
-) -> Result<()> {
-    let manifest_path = cache.join("manifest.json");
-
-    let mut manifest: HashMap<String, HashMap<String, String>> = fs::read_to_string(&manifest_path)
-        .ok()
-        .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or_default();
-
-    manifest.insert(theme.to_string(), persona_map.clone());
-
-    let json = serde_json::to_string_pretty(&manifest).map_err(|e| ForestageError::Session {
-        message: format!("failed to serialize manifest: {e}"),
-    })?;
-
-    fs::write(&manifest_path, json).map_err(|e| ForestageError::Session {
-        message: format!("failed to write manifest: {e}"),
-    })
 }
 
 /// Check if a command exists on PATH.


### PR DESCRIPTION
## Summary

Closes the loop on the granny→ponder fix (PR #58, orc finding-033). After PR #58 stopped \`portrait.rs\` consulting the manifest's \`personas\` role-key index, the index itself became dead weight: still emitted by the publishing script, still deserialized by the client, still documented in the design doc. This PR removes it from all three places, and regenerates + republishes the CDN manifest to match.

Bundles two bd tickets: \`aae-orc-h89c\` (Option A — code) and \`aae-orc-8az5\` (Option B — script + doc + CDN).

## What changed

**\`src/download.rs\`** (~30 lines deleted):
- Drop \`RemoteManifest.personas\` field — serde ignores unknown JSON fields by default, so existing manifests still deserialize.
- Drop \`merge_local_manifest()\` and its call site in \`ensure_portraits\`.
- Local cache no longer materializes a \`manifest.json\` shim; \`cache_status()\` already skipped it by name.

**\`scripts/portraits/gen-manifest.sh\`** (115 lines → 60 lines):
- Drop the \`personas\` section emission and the per-theme \`yq\` walk.
- Drop the \`THEMES_DIR\` positional arg; signature is now \`(dist-dir, [base-url])\`. \`yq\` no longer required.

**\`docs/design/portrait-distribution.md\`**:
- Status note at top — portrait resolution is now Character-derived (B14, finding-033).
- §2: drop \`personas\` from example; mark historical.
- New §Portrait Resolution: derived-stem chain (shortName → full name → first name; exact then prefix match per size dir), explains the hashed CDN filenames and the granny→ponder regression class.
- §3 gen-manifest.sh excerpt collapsed to a usage summary + pointer to the live script.
- §4b download.rs excerpt: status note explaining drift between sketch and current source.
- §5 Flat Layout Migration: marked "never built".
- §6 Changes Summary: second table for the post-B14 cleanup pass.
- §7 Testing Plan: drop dead \`merge_local_manifest\` test, add the granny→ponder regression test row.

## CDN regenerated and uploaded

Ran \`scripts/portraits/gen-manifest.sh dist/portraits > dist/portraits/manifest.json\` against the local pack archive (100 themes, no SHA changes vs prior manifest), then \`scripts/portraits/upload-r2.sh dist/portraits\`.

Live verification:

\`\`\`
$ curl -sI https://portraits.darkatelier.org/v1/manifest.json | head -7
HTTP/2 200
content-type: application/json
content-length: 15060             # was 46334 (-67%)
etag: "716ceddef1697062b0da73df922246e9"        # was 22dfce0c0e74e5ab9d4084aaf5535b5e
last-modified: Sun, 26 Apr 2026 21:01:36 GMT    # was Sun, 12 Apr 2026 05:07:13 GMT

$ curl -s https://portraits.darkatelier.org/v1/manifest.json | jq 'keys, (.themes | length)'
[ "base_url", "schema", "themes", "updated" ]
100
\`\`\`

100 themes, no \`personas\` key, base_url unchanged. Pack \`.tar.gz\` files re-checked by rclone — zero bytes transferred (no SHA drift).

## Test plan

- [x] \`cargo test\` — 161 lib + 5 integration pass
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo +nightly fmt --all -- --check\` — clean
- [x] Lefthook pre-commit fmt-check passed
- [x] Manifest regen against local dist — same SHA256s, no theme additions/removals, only \`personas\` field gone + \`updated\` timestamp refreshed
- [x] Manifest uploaded to R2; live etag advanced; live body contains 100 themes and no \`personas\` field
- [ ] Manual smoke: fresh \`forestage --theme dune --persona paul-atreides\` on a clean cache downloads the dune pack and renders the portrait

Refs: aae-orc-h89c, aae-orc-8az5