### PR TITLE
ci: guard scorecard behind SCORECARD_ENABLED repo var

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -20,6 +20,9 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
+    # Default off — enable by setting repo variable SCORECARD_ENABLED=true
+    # (same opt-in pattern as SIGNING_ENABLED).
+    if: vars.SCORECARD_ENABLED == 'true'
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.


### PR DESCRIPTION
Scorecard analysis becomes opt-in: the job runs only when the repo variable `SCORECARD_ENABLED` is set to `true` — the same opt-in pattern as `SIGNING_ENABLED`. No var, no run. Fleet-wide sweep; default is off everywhere until the variable is added per repo.